### PR TITLE
Replace klee_output_error with klee_bound_error

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -156,7 +156,7 @@ extern "C" {
   void klee_merge();
 
   /* Outputs floating-point error expression */
-  void klee_output_error(uintptr_t n);
+  void klee_bound_error(uintptr_t n, double bound);
 
 #ifdef __cplusplus
 }

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -427,7 +427,16 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
   assert(arguments.size() == 2 &&
          "invalid number of arguments to klee_bound_error");
 
-  state.symbolicError->outputErrorBound(target->inst);
+  if (ConstantExpr *ce = llvm::dyn_cast<ConstantExpr>(arguments.at(1))) {
+    uint64_t intValue = ce->getZExtValue();
+    double *boundPtr = reinterpret_cast<double *>(&intValue);
+    double bound = *boundPtr;
+
+    state.symbolicError->outputErrorBound(target->inst, bound);
+    return;
+  }
+
+  assert(!"second argument of klee_bound_error must be constant");
 }
 
 void SpecialFunctionHandler::handlePreferCex(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -427,7 +427,7 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
   assert(arguments.size() == 2 &&
          "invalid number of arguments to klee_bound_error");
 
-  state.symbolicError->addOutput(target->inst);
+  state.symbolicError->outputErrorBound(target->inst);
 }
 
 void SpecialFunctionHandler::handlePreferCex(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -96,7 +96,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_make_symbolic", handleMakeSymbolic, false),
   add("klee_mark_global", handleMarkGlobal, false),
   add("klee_merge", handleMerge, false),
-  add("klee_output_error", handleOutputError, false),
+  add("klee_bound_error", handleBoundError, false),
   add("klee_prefer_cex", handlePreferCex, false),
   add("klee_posix_prefer_cex", handlePosixPreferCex, false),
   add("klee_print_expr", handlePrintExpr, false),
@@ -421,11 +421,11 @@ void SpecialFunctionHandler::handleIsSymbolic(ExecutionState &state,
 }
 
 void
-SpecialFunctionHandler::handleOutputError(ExecutionState &state,
-                                          KInstruction *target,
-                                          std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size() == 1 &&
-         "invalid number of arguments to klee_output_error");
+SpecialFunctionHandler::handleBoundError(ExecutionState &state,
+                                         KInstruction *target,
+                                         std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 2 &&
+         "invalid number of arguments to klee_bound_error");
 
   state.symbolicError->addOutput(target->inst);
 }

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -119,7 +119,7 @@ namespace klee {
     HANDLER(handleMerge);
     HANDLER(handleNew);
     HANDLER(handleNewArray);
-    HANDLER(handleOutputError);
+    HANDLER(handleBoundError);
     HANDLER(handlePreferCex);
     HANDLER(handlePosixPreferCex);
     HANDLER(handlePrintExpr);

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -76,7 +76,7 @@ ref<Expr> SymbolicError::getError(Executor *executor, ref<Expr> valueExpr,
 
 SymbolicError::~SymbolicError() {}
 
-void SymbolicError::addOutput(llvm::Instruction *inst) {
+void SymbolicError::outputErrorBound(llvm::Instruction *inst) {
   ref<Expr> e =
       valueErrorMap[llvm::dyn_cast<llvm::Instruction>(inst->getOperand(0))];
   if (e.isNull()) {

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -40,7 +40,7 @@ public:
 
   ~SymbolicError();
 
-  void addOutput(llvm::Instruction *inst);
+  void outputErrorBound(llvm::Instruction *inst);
 
   ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
                            ref<Expr> result,

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -42,7 +42,7 @@ public:
 
   ~SymbolicError();
 
-  void outputErrorBound(llvm::Instruction *inst);
+  void outputErrorBound(llvm::Instruction *inst, double bound);
 
   ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
                            ref<Expr> result,

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -414,7 +414,7 @@ unsigned klee_is_symbolic(uintptr_t x) {
   return 0;
 }
 
-void klee_output_error(uintptr_t x) { ; }
+void klee_bound_error(uintptr_t x, double bound) { ; }
 
 void klee_prefer_cex(void *buffer, uintptr_t condition) {
   ;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -760,7 +760,7 @@ static const char *modelledExternals[] = {
   "klee_make_symbolic",
   "klee_mark_global",
   "klee_merge",
-  "klee_output_error",
+  "klee_bound_error",
   "klee_prefer_cex",
   "klee_print_expr",
   "klee_print_range",


### PR DESCRIPTION
`klee_bound_error` accepts second argument that is a constant double. This argument is the error bound of the output, to be combined with the output error expression as a constraint.