### PR TITLE
Added klee_track_error API

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -158,6 +158,9 @@ extern "C" {
   /* Outputs floating-point error expression */
   void klee_bound_error(uintptr_t n, double bound);
 
+  /* Track error amount of a memory object */
+  void klee_track_error(void *addr, const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3769,6 +3769,24 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
   }
 }
 
+void Executor::executeStoreError(ExecutionState &state, const uintptr_t address,
+                                 const std::string &name) {
+  // Find a unique name for this array.  First try the original name,
+  // or if that fails try adding a unique identifier. Shamelessly copied from
+  // executeMakeSymbolic.
+  unsigned id = 0;
+  std::string uniqueName = name;
+  while (!state.arrayNames.insert(uniqueName).second) {
+    uniqueName = name + "_" + llvm::utostr(++id);
+  }
+  const Array *array = arrayCache.CreateArray(uniqueName, Expr::Int8);
+  ref<Expr> errorExpr = ReadExpr::create(
+      UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
+  ref<Expr> addressExpr = Expr::createPointer(address);
+
+  state.symbolicError->executeStore(addressExpr, errorExpr);
+}
+
 /***/
 
 void Executor::runFunctionAsMain(Function *f,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -286,6 +286,10 @@ private:
   void executeMakeSymbolic(ExecutionState &state, const MemoryObject *mo,
                            const std::string &name);
 
+  // store the error amount of a memory object at a given address
+  void executeStoreError(ExecutionState &state, const uintptr_t address,
+                         const std::string &name);
+
   /// Create a new state where each input condition has been added as
   /// a constraint and return the results. The input state is included
   /// as one of the results. Note that the output vector may included

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -103,6 +103,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_print_range", handlePrintRange, false),
   add("klee_set_forking", handleSetForking, false),
   add("klee_stack_trace", handleStackTrace, false),
+  add("klee_track_error", handleTrackError, false),
   add("klee_warning", handleWarning, false),
   add("klee_warning_once", handleWarningOnce, false),
   add("klee_alias_function", handleAliasFunction, false),
@@ -437,6 +438,35 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
   }
 
   assert(!"second argument of klee_bound_error must be constant");
+}
+
+void
+SpecialFunctionHandler::handleTrackError(ExecutionState &state,
+                                         KInstruction *target,
+                                         std::vector<ref<Expr> > &arguments) {
+  std::string name;
+
+  // FIXME: For backwards compatibility, we should eventually enforce the
+  // correct arguments.
+  if (arguments.size() == 1) {
+    name = "unnamed_error";
+  } else {
+    // FIXME: Should be a user.err, not an assert.
+    assert(arguments.size() == 2 &&
+           "invalid number of arguments to klee_track_error");
+    name = readStringAtAddress(state, arguments[1]);
+  }
+
+  if (ConstantExpr *ac = llvm::dyn_cast<ConstantExpr>(arguments.at(0))) {
+    uintptr_t address = reinterpret_cast<uintptr_t>(ac->getZExtValue());
+    executor.executeStoreError(state, reinterpret_cast<uintptr_t>(address),
+                               name);
+    return;
+  }
+
+  executor.terminateStateOnError(
+      state, "first argument of track_error must be a constant address",
+      "user.err");
 }
 
 void SpecialFunctionHandler::handlePreferCex(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -131,6 +131,7 @@ namespace klee {
     HANDLER(handleSetForking);
     HANDLER(handleSilentExit);
     HANDLER(handleStackTrace);
+    HANDLER(handleTrackError);
     HANDLER(handleUnderConstrained);
     HANDLER(handleWarning);
     HANDLER(handleWarningOnce);

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -30,7 +30,8 @@ ref<Expr> SymbolicError::getError(Executor *executor, ref<Expr> valueExpr,
         llvm::dyn_cast<ReadExpr>(concatExpr->getLeft())->updates.root;
       const Array *errorArray = arrayErrorArrayMap[concatArray];
       if (!errorArray) {
-        std::string errorName("_fractional_error_" +
+        // The error expression is not found; use an unspecified value
+        std::string errorName("_unspecified_error_" +
                               llvm::dyn_cast<ReadExpr>(concatExpr->getLeft())
                                   ->updates.root->name);
         const Array *newErrorArray =
@@ -46,7 +47,8 @@ ref<Expr> SymbolicError::getError(Executor *executor, ref<Expr> valueExpr,
       const Array *readArray = readExpr->updates.root;
       const Array *errorArray = arrayErrorArrayMap[readArray];
       if (!errorArray) {
-        std::string errorName("_fractional_error_" +
+        // The error expression is not found; use an unspecified value
+        std::string errorName("_unspecified_error_" +
                               readExpr->updates.root->name);
         const Array *newErrorArray =
             errorArrayCache.CreateArray(errorName, Expr::Int8);

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -416,6 +416,8 @@ unsigned klee_is_symbolic(uintptr_t x) {
 
 void klee_bound_error(uintptr_t x, double bound) { ; }
 
+void klee_track_error(void *addr, const char *name) { ; }
+
 void klee_prefer_cex(void *buffer, uintptr_t condition) {
   ;
 }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -771,6 +771,7 @@ static const char *modelledExternals[] = {
   "klee_warning_once",
   "klee_alias_function",
   "klee_stack_trace",
+  "klee_track_error",
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
   "llvm.dbg.declare",
   "llvm.dbg.value",


### PR DESCRIPTION
@Himeshi  `klee_track_error` is needed to specify the variable name of the input error. Whenever the input error is unspecified, `_unspecified_error_<varname>` will be used for the error amount of variable `<varname>`. Please see the sample usage of `klee_track_error` in `basic/get_sign.c` of `fp-examples` repository.