### PR TITLE
Treat symbolic floating point as symbolic int

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -55,7 +55,9 @@ extern llvm::cl::opt<CoreSolverType> CoreSolverToUse;
 
 extern llvm::cl::opt<CoreSolverType> DebugCrossCheckCoreSolverWith;
 
-extern llvm::cl::opt<bool> DebugFPError;
+extern llvm::cl::opt<bool> FloatingPointError;
+
+extern llvm::cl::opt<bool> DebugFloatingPointError;
 
 #ifdef ENABLE_METASMT
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -83,10 +83,15 @@ llvm::cl::list<QueryLoggingSolverType> queryLoggingOptions(
 );
 
 llvm::cl::opt<bool>
-DebugFPError("debug-fp-error",
-             llvm::cl::desc(
-                 "Output debugging trace for floating-point error propagation"),
-             llvm::cl::init(false));
+FloatingPointError("floating-point-error",
+                   llvm::cl::desc("Switch on floating-point error analysis"),
+                   llvm::cl::init(false));
+
+llvm::cl::opt<bool> DebugFloatingPointError(
+    "debug-floating-point-error",
+    llvm::cl::desc(
+        "Output debugging trace for floating-point error propagation"),
+    llvm::cl::init(false));
 
 #ifdef ENABLE_METASMT
 


### PR DESCRIPTION
@Himeshi Added `-floating-point-error` option and renamed `-debug-fp-error` to `-debug-floating-point-error`. The `-floating-point-error` option enables the treatment of floating-point values as int values, including symbolic floating points. Although not semantically correct, this allows conditional branchings with conditions that depend on floating-point values to be explored.