### PR TITLE
Segfaults fix

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1135,6 +1135,14 @@ void Executor::bindArgument(KFunction *kf, unsigned index,
   getArgumentCell(state, kf, index).value = value;
 }
 
+void Executor::bindArgument(KFunction *kf, unsigned index,
+                            ExecutionState &state, ref<Expr> value,
+                            ref<Expr> error) {
+  Cell &c = getArgumentCell(state, kf, index);
+  c.value = value;
+  c.error = error;
+}
+
 ref<Expr> Executor::toUnique(const ExecutionState &state, 
                              ref<Expr> &e) {
   ref<Expr> result = e;
@@ -1466,7 +1474,7 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
 
     unsigned numFormals = f->arg_size();
     for (unsigned i = 0; i < numFormals; ++i)
-      bindArgument(kf, i, state, arguments[i].value);
+      bindArgument(kf, i, state, arguments[i].value, arguments[i].error);
   }
 }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1874,6 +1874,14 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
         }
       }
 
+      if (PrecisionError) {
+        ref<Expr> dummyResult = ConstantExpr::create(0, Expr::Int8);
+        std::vector<ref<Expr> > errors;
+        for (unsigned j = 0; j < arguments.size(); ++j) {
+          errors.push_back(arguments[j].error);
+        }
+        state.symbolicError->propagateError(this, i, dummyResult, errors);
+      }
       executeCall(state, ki, f, arguments);
     } else {
       ref<Expr> v = eval(ki, 0, state).value;
@@ -1901,6 +1909,14 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
                                 "resolved symbolic function pointer to: %s",
                                 f->getName().data());
 
+            if (PrecisionError) {
+              ref<Expr> dummyResult = ConstantExpr::create(0, Expr::Int8);
+              std::vector<ref<Expr> > errors;
+              for (unsigned j = 0; j < arguments.size(); ++j) {
+                errors.push_back(arguments[j].error);
+              }
+              state.symbolicError->propagateError(this, i, dummyResult, errors);
+            }
             executeCall(*res.first, ki, f, arguments);
           } else {
             if (!hasInvalid) {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1954,9 +1954,15 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     Cell c1 = eval(ki, 1, state);
     ref<Expr> tExpr = c1.value;
     ref<Expr> terror = c1.error;
+    if (terror.isNull())
+      terror = state.symbolicError->retrieveError(ki->inst->getOperand(1));
+
     Cell c2 = eval(ki, 2, state);
     ref<Expr> fExpr = c2.value;
     ref<Expr> ferror = c2.error;
+    if (ferror.isNull())
+      ferror = state.symbolicError->retrieveError(ki->inst->getOperand(1));
+
     ref<Expr> result = SelectExpr::create(cond, tExpr, fExpr);
     ref<Expr> error = SelectExpr::create(cond, terror, ferror);
     bindLocal(ki, state, result, error);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1940,7 +1940,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 #endif
     ref<Expr> result = c.value;
     ref<Expr> error = c.error;
-    bindLocal(ki, state, result, error);
+    // We use the arguments list as a carrier for the error amount
+    std::vector<ref<Expr> > errors;
+    errors.push_back(error);
+    bindLocal(ki, state, result,
+              state.symbolicError->propagateError(this, i, result, errors));
     break;
   }
 

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -351,6 +351,8 @@ private:
                     unsigned index,
                     ExecutionState &state,
                     ref<Expr> value);
+  void bindArgument(KFunction *kf, unsigned index, ExecutionState &state,
+                    ref<Expr> value, ref<Expr> error);
 
   ref<klee::ConstantExpr> evalConstantExpr(const llvm::ConstantExpr *ce);
 

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -293,7 +293,6 @@ ref<Expr> SymbolicError::propagateError(Executor *executor,
       std::map<llvm::Value *, ref<Expr> >::iterator it = valueErrorMap.find(v);
       if (it != valueErrorMap.end()) {
         error = valueErrorMap[v];
-        break;
       }
       if (error->getWidth() > Expr::Int8)
         error = ExtractExpr::create(error, 0, Expr::Int8);

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -127,6 +127,11 @@ ref<Expr> SymbolicError::propagateError(Executor *executor,
                                         ref<Expr> result,
                                         std::vector<ref<Expr> > &arguments) {
   switch (instr->getOpcode()) {
+  case llvm::Instruction::PHI: {
+    ref<Expr> error = arguments.at(0);
+    valueErrorMap[instr] = error;
+    return error;
+  }
   case llvm::Instruction::Call:
   case llvm::Instruction::Invoke: {
     ref<Expr> dummyError = ConstantExpr::create(0, Expr::Int8);

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -40,7 +40,11 @@ class SymbolicError {
 public:
   SymbolicError() {}
 
-  SymbolicError(SymbolicError &symErr) { storedError = symErr.storedError; }
+  SymbolicError(SymbolicError &symErr) {
+    storedError = symErr.storedError;
+    // FIXME: Simple copy for now.
+    valueErrorMap = symErr.valueErrorMap;
+  }
 
   ~SymbolicError();
 
@@ -49,6 +53,8 @@ public:
   ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
                            ref<Expr> result,
                            std::vector<ref<Expr> > &arguments);
+
+  ref<Expr> retrieveError(llvm::Value *value) { return valueErrorMap[value]; }
 
   std::string getOutputString() { return outputString; }
 


### PR DESCRIPTION
@Himeshi This PR resolves segmentation fault issues in the error propagator. The problems were exposed when the bitcode is preprocessed using `mem2reg`.
