### PR TITLE
Pretty expressions

### DIFF
--- a/include/klee/util/PrettyExpressionBuilder.h
+++ b/include/klee/util/PrettyExpressionBuilder.h
@@ -1,0 +1,129 @@
+//===--- PrettyExpressionBuilder.h - Easier-to-read expressions -*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Functions to help display object contents.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_TXPRINTUTIL_H
+#define KLEE_TXPRINTUTIL_H
+
+#include "klee/Config/Version.h"
+#include "klee/Constraints.h"
+#include "klee/Expr.h"
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+#include <llvm/IR/Value.h>
+#else
+#include <llvm/Value.h>
+#endif
+
+#include <string>
+
+namespace klee {
+
+/// Encapsulates functionality of expression builder
+class PrettyExpressionBuilder {
+
+  std::string bvOne() {
+    return "1";
+  };
+  std::string bvZero() {
+    return "0";
+  };
+  std::string bvMinusOne() { return "-1"; }
+  std::string bvConst32(uint32_t value);
+  std::string bvConst64(uint64_t value);
+  std::string bvZExtConst(uint64_t value);
+  std::string bvSExtConst(uint64_t value);
+
+  std::string bvBoolExtract(std::string expr, int bit);
+  std::string bvExtract(std::string expr, unsigned top, unsigned bottom);
+  std::string eqExpr(std::string a, std::string b);
+
+  // logical left and right shift (not arithmetic)
+  std::string bvLeftShift(std::string expr, unsigned shift);
+  std::string bvRightShift(std::string expr, unsigned shift);
+  std::string bvVarLeftShift(std::string expr, std::string shift);
+  std::string bvVarRightShift(std::string expr, std::string shift);
+  std::string bvVarArithRightShift(std::string expr, std::string shift);
+
+  // Some STP-style bitvector arithmetic
+  std::string bvMinusExpr(std::string minuend, std::string subtrahend);
+  std::string bvPlusExpr(std::string augend, std::string addend);
+  std::string bvMultExpr(std::string multiplacand, std::string multiplier);
+  std::string bvDivExpr(std::string dividend, std::string divisor);
+  std::string sbvDivExpr(std::string dividend, std::string divisor);
+  std::string bvModExpr(std::string dividend, std::string divisor);
+  std::string sbvModExpr(std::string dividend, std::string divisor);
+  std::string notExpr(std::string expr);
+  std::string bvAndExpr(std::string lhs, std::string rhs);
+  std::string bvOrExpr(std::string lhs, std::string rhs);
+  std::string iffExpr(std::string lhs, std::string rhs);
+  std::string bvXorExpr(std::string lhs, std::string rhs);
+  std::string bvSignExtend(std::string src);
+
+  // Some STP-style array domain interface
+  std::string writeExpr(std::string array, std::string index,
+                        std::string value);
+  std::string readExpr(std::string array, std::string index);
+
+  // ITE-expression constructor
+  std::string iteExpr(std::string condition, std::string whenTrue,
+                      std::string whenFalse);
+
+  // Bitvector comparison
+  std::string bvLtExpr(std::string lhs, std::string rhs);
+  std::string bvLeExpr(std::string lhs, std::string rhs);
+  std::string sbvLtExpr(std::string lhs, std::string rhs);
+  std::string sbvLeExpr(std::string lhs, std::string rhs);
+
+  std::string existsExpr(std::string body);
+
+  std::string constructAShrByConstant(std::string expr, unsigned shift,
+                                      std::string isSigned);
+  std::string constructMulByConstant(std::string expr, uint64_t x);
+  std::string constructUDivByConstant(std::string expr_n, uint64_t d);
+  std::string constructSDivByConstant(std::string expr_n, uint64_t d);
+
+  std::string getInitialArray(const Array *root);
+  std::string getArrayForUpdate(const Array *root, const UpdateNode *un);
+
+  std::string constructActual(ref<Expr> e);
+
+  std::string buildArray(const char *name, unsigned indexWidth,
+                         unsigned valueWidth);
+
+  std::string getTrue();
+  std::string getFalse();
+  std::string getInitialRead(const Array *root, unsigned index);
+
+  PrettyExpressionBuilder();
+
+  ~PrettyExpressionBuilder();
+
+public:
+  static std::string construct(ref<Expr> e);
+
+  static std::string constructQuery(ConstraintManager &constraints,
+                                    ref<Expr> e);
+};
+
+/// \brief Output function name to the output stream
+extern bool outputFunctionName(llvm::Value *value, llvm::raw_ostream &stream);
+
+/// \brief Create 8 times padding amount of spaces
+extern std::string makeTabs(const unsigned paddingAmount);
+
+/// \brief Create 1 padding amount of spaces
+extern std::string appendTab(const std::string &prefix);
+}
+
+#endif

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -12,6 +12,7 @@
 #include "klee/CommandLine.h"
 #include "klee/Config/Version.h"
 #include "klee/Internal/Module/TripCounter.h"
+#include "klee/util/PrettyExpressionBuilder.h"
 
 #include "llvm/DebugInfo.h"
 
@@ -132,7 +133,7 @@ void ErrorState::outputErrorBound(llvm::Instruction *inst, double bound) {
   }
 
   stream << errorVar << " == (";
-  e->print(stream);
+  stream << PrettyExpressionBuilder::construct(e);
   stream << ") && ";
   stream << "(" << errorVar << " <= " << bound << ") && ";
   stream << "(" << errorVar << " >= -" << bound << ")\n";

--- a/lib/Core/PrettyExpressionBuilder.cpp
+++ b/lib/Core/PrettyExpressionBuilder.cpp
@@ -71,13 +71,13 @@ std::string PrettyExpressionBuilder::bvSExtConst(uint64_t value) {
 }
 std::string PrettyExpressionBuilder::bvBoolExtract(std::string expr, int bit) {
   std::ostringstream stream;
-  stream << expr << "[" << bit << "]";
+  stream << expr;
   return stream.str();
 }
 std::string PrettyExpressionBuilder::bvExtract(std::string expr, unsigned top,
                                                unsigned bottom) {
   std::ostringstream stream;
-  stream << expr << "[" << top << "," << bottom << "]";
+  stream << expr;
   return stream.str();
 }
 std::string PrettyExpressionBuilder::eqExpr(std::string a, std::string b) {
@@ -171,14 +171,14 @@ std::string PrettyExpressionBuilder::writeExpr(std::string array,
 }
 std::string PrettyExpressionBuilder::readExpr(std::string array,
                                               std::string index) {
-  return array + "[" + index + "]";
+  return array;
 }
 
 // ITE-expression constructor
 std::string PrettyExpressionBuilder::iteExpr(std::string condition,
                                              std::string whenTrue,
                                              std::string whenFalse) {
-  return "ite(" + condition + "," + whenTrue + "," + whenFalse + ")";
+  return "((" + condition + ") ? " + whenTrue + "," + whenFalse + ")";
 }
 
 // Bitvector comparison
@@ -290,9 +290,6 @@ std::string PrettyExpressionBuilder::constructActual(ref<Expr> e) {
     ConcatExpr *ce = cast<ConcatExpr>(e);
     unsigned numKids = ce->getNumKids();
     std::string res = constructActual(ce->getKid(numKids - 1));
-    for (int i = numKids - 2; i >= 0; i--) {
-      res = constructActual(ce->getKid(i)) + "." + res;
-    }
     return res;
   }
 

--- a/lib/Core/PrettyExpressionBuilder.cpp
+++ b/lib/Core/PrettyExpressionBuilder.cpp
@@ -1,0 +1,550 @@
+//===-- PrettyExpressionBuilder ---------------------------------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Functions to help display object contents.
+///
+//===----------------------------------------------------------------------===//
+
+#include "klee/util/PrettyExpressionBuilder.h"
+
+#if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instruction.h>
+#else
+#include <llvm/BasicBlock.h>
+#include <llvm/Function.h>
+#include <llvm/Instruction.h>
+#endif
+
+using namespace klee;
+
+namespace klee {
+
+bool outputFunctionName(llvm::Value *value, llvm::raw_ostream &stream) {
+  llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(value);
+  if (inst) {
+    llvm::BasicBlock *bb = inst->getParent();
+    if (bb) {
+      llvm::Function *f = bb->getParent();
+      stream << f->getName();
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string makeTabs(const unsigned paddingAmount) {
+  std::string tabsString;
+  for (unsigned i = 0; i < paddingAmount; ++i) {
+    tabsString += appendTab(tabsString);
+  }
+  return tabsString;
+}
+
+std::string appendTab(const std::string &prefix) { return prefix + "        "; }
+
+/**/
+
+std::string PrettyExpressionBuilder::bvConst32(uint32_t value) {
+  std::ostringstream stream;
+  stream << value;
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::bvConst64(uint64_t value) {
+  std::ostringstream stream;
+  stream << value;
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::bvZExtConst(uint64_t value) {
+  return bvConst64(value);
+}
+std::string PrettyExpressionBuilder::bvSExtConst(uint64_t value) {
+  return bvConst64(value);
+}
+std::string PrettyExpressionBuilder::bvBoolExtract(std::string expr, int bit) {
+  std::ostringstream stream;
+  stream << expr << "[" << bit << "]";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::bvExtract(std::string expr, unsigned top,
+                                               unsigned bottom) {
+  std::ostringstream stream;
+  stream << expr << "[" << top << "," << bottom << "]";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::eqExpr(std::string a, std::string b) {
+  if (a == "false")
+    return "!" + b;
+  return "(" + a + " = " + b + ")";
+}
+
+// logical left and right shift (not arithmetic)
+std::string PrettyExpressionBuilder::bvLeftShift(std::string expr,
+                                                 unsigned shift) {
+  std::ostringstream stream;
+  stream << "(" << expr << " \\<\\< " << shift << ")";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::bvRightShift(std::string expr,
+                                                  unsigned shift) {
+  std::ostringstream stream;
+  stream << "(" << expr << " \\>\\> " << shift << ")";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::bvVarLeftShift(std::string expr,
+                                                    std::string shift) {
+  return "(" + expr + " \\<\\< " + shift + ")";
+}
+std::string PrettyExpressionBuilder::bvVarRightShift(std::string expr,
+                                                     std::string shift) {
+  return "(" + expr + " \\>\\> " + shift + ")";
+}
+std::string PrettyExpressionBuilder::bvVarArithRightShift(std::string expr,
+                                                          std::string shift) {
+  return bvVarRightShift(expr, shift);
+}
+
+// Some STP-style bitvector arithmetic
+std::string PrettyExpressionBuilder::bvMinusExpr(std::string minuend,
+                                                 std::string subtrahend) {
+  return "(" + minuend + " - " + subtrahend + ")";
+}
+std::string PrettyExpressionBuilder::bvPlusExpr(std::string augend,
+                                                std::string addend) {
+  return "(" + augend + " + " + addend + ")";
+}
+std::string PrettyExpressionBuilder::bvMultExpr(std::string multiplacand,
+                                                std::string multiplier) {
+  return "(" + multiplacand + " * " + multiplier + ")";
+}
+std::string PrettyExpressionBuilder::bvDivExpr(std::string dividend,
+                                               std::string divisor) {
+  return "(" + dividend + " / " + divisor + ")";
+}
+std::string PrettyExpressionBuilder::sbvDivExpr(std::string dividend,
+                                                std::string divisor) {
+  return "(" + dividend + " / " + divisor + ")";
+}
+std::string PrettyExpressionBuilder::bvModExpr(std::string dividend,
+                                               std::string divisor) {
+  return "(" + dividend + " % " + divisor + ")";
+}
+std::string PrettyExpressionBuilder::sbvModExpr(std::string dividend,
+                                                std::string divisor) {
+  return "(" + dividend + " % " + divisor + ")";
+}
+std::string PrettyExpressionBuilder::notExpr(std::string expr) {
+  return "!(" + expr + ")";
+}
+std::string PrettyExpressionBuilder::bvAndExpr(std::string lhs,
+                                               std::string rhs) {
+  return "(" + lhs + " & " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::bvOrExpr(std::string lhs,
+                                              std::string rhs) {
+  return "(" + lhs + " \\| " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::iffExpr(std::string lhs, std::string rhs) {
+  return "(" + lhs + " \\<=\\> " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::bvXorExpr(std::string lhs,
+                                               std::string rhs) {
+  return "(" + lhs + " xor " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::bvSignExtend(std::string src) {
+  return src;
+}
+
+// Some STP-style array domain interface
+std::string PrettyExpressionBuilder::writeExpr(std::string array,
+                                               std::string index,
+                                               std::string value) {
+  return "update(" + array + "," + index + "," + value + ")";
+}
+std::string PrettyExpressionBuilder::readExpr(std::string array,
+                                              std::string index) {
+  return array + "[" + index + "]";
+}
+
+// ITE-expression constructor
+std::string PrettyExpressionBuilder::iteExpr(std::string condition,
+                                             std::string whenTrue,
+                                             std::string whenFalse) {
+  return "ite(" + condition + "," + whenTrue + "," + whenFalse + ")";
+}
+
+// Bitvector comparison
+std::string PrettyExpressionBuilder::bvLtExpr(std::string lhs,
+                                              std::string rhs) {
+  return "(" + lhs + " \\< " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::bvLeExpr(std::string lhs,
+                                              std::string rhs) {
+  return "(" + lhs + " \\<= " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::sbvLtExpr(std::string lhs,
+                                               std::string rhs) {
+  return "(" + lhs + " \\< " + rhs + ")";
+}
+std::string PrettyExpressionBuilder::sbvLeExpr(std::string lhs,
+                                               std::string rhs) {
+  return "(" + lhs + " \\<= " + rhs + ")";
+}
+
+std::string PrettyExpressionBuilder::constructAShrByConstant(
+    std::string expr, unsigned shift, std::string isSigned) {
+  return bvRightShift(expr, shift);
+}
+std::string PrettyExpressionBuilder::constructMulByConstant(std::string expr,
+                                                            uint64_t x) {
+  std::ostringstream stream;
+  stream << "(" << expr << " * " << x << ")";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::constructUDivByConstant(std::string expr,
+                                                             uint64_t d) {
+  std::ostringstream stream;
+  stream << "(" << expr << " / " << d << ")";
+  return stream.str();
+}
+std::string PrettyExpressionBuilder::constructSDivByConstant(std::string expr,
+                                                             uint64_t d) {
+  std::ostringstream stream;
+  stream << "(" << expr << " / " << d << ")";
+  return stream.str();
+}
+
+std::string PrettyExpressionBuilder::getInitialArray(const Array *root) {
+  std::string arrayExpr =
+      buildArray(root->name.c_str(), root->getDomain(), root->getRange());
+
+  if (root->isConstantArray()) {
+    for (unsigned i = 0, e = root->size; i != e; ++i) {
+      std::string prev = arrayExpr;
+      arrayExpr = writeExpr(
+          prev, constructActual(ConstantExpr::create(i, root->getDomain())),
+          constructActual(root->constantValues[i]));
+    }
+  }
+  return arrayExpr;
+}
+std::string PrettyExpressionBuilder::getArrayForUpdate(const Array *root,
+                                                       const UpdateNode *un) {
+  if (!un) {
+    return (getInitialArray(root));
+  }
+  return writeExpr(getArrayForUpdate(root, un->next),
+                   constructActual(un->index), constructActual(un->value));
+}
+
+std::string PrettyExpressionBuilder::constructActual(ref<Expr> e) {
+  switch (e->getKind()) {
+  case Expr::Constant: {
+    ConstantExpr *CE = cast<ConstantExpr>(e);
+    int width = CE->getWidth();
+
+    // Coerce to bool if necessary.
+    if (width == 1)
+      return CE->isTrue() ? getTrue() : getFalse();
+
+    // Fast path.
+    if (width <= 32)
+      return bvConst32(CE->getZExtValue(32));
+    if (width <= 64)
+      return bvConst64(CE->getZExtValue());
+
+    ref<ConstantExpr> Tmp = CE;
+    return bvConst64(Tmp->Extract(0, 64)->getZExtValue());
+  }
+
+  // Special
+  case Expr::NotOptimized: {
+    NotOptimizedExpr *noe = cast<NotOptimizedExpr>(e);
+    return constructActual(noe->src);
+  }
+
+  case Expr::Read: {
+    ReadExpr *re = cast<ReadExpr>(e);
+    assert(re && re->updates.root);
+    return readExpr(getArrayForUpdate(re->updates.root, re->updates.head),
+                    constructActual(re->index));
+  }
+
+  case Expr::Select: {
+    SelectExpr *se = cast<SelectExpr>(e);
+    std::string cond = constructActual(se->cond);
+    std::string tExpr = constructActual(se->trueExpr);
+    std::string fExpr = constructActual(se->falseExpr);
+    return iteExpr(cond, tExpr, fExpr);
+  }
+
+  case Expr::Concat: {
+    ConcatExpr *ce = cast<ConcatExpr>(e);
+    unsigned numKids = ce->getNumKids();
+    std::string res = constructActual(ce->getKid(numKids - 1));
+    for (int i = numKids - 2; i >= 0; i--) {
+      res = constructActual(ce->getKid(i)) + "." + res;
+    }
+    return res;
+  }
+
+  case Expr::Extract: {
+    ExtractExpr *ee = cast<ExtractExpr>(e);
+    std::string src = constructActual(ee->expr);
+    int width = ee->getWidth();
+    if (width == 1) {
+      return bvBoolExtract(src, ee->offset);
+    } else {
+      return bvExtract(src, ee->offset + width - 1, ee->offset);
+    }
+  }
+
+  // Casting
+  case Expr::ZExt: {
+    CastExpr *ce = cast<CastExpr>(e);
+    std::string src = constructActual(ce->src);
+    int width = ce->getWidth();
+    if (width == 1) {
+      return iteExpr(src, bvOne(), bvZero());
+    } else {
+      return src;
+    }
+  }
+
+  case Expr::SExt: {
+    CastExpr *ce = cast<CastExpr>(e);
+    std::string src = constructActual(ce->src);
+    return bvSignExtend(src);
+  }
+
+  // Arithmetic
+  case Expr::Add: {
+    AddExpr *ae = cast<AddExpr>(e);
+    std::string left = constructActual(ae->left);
+    std::string right = constructActual(ae->right);
+    return bvPlusExpr(left, right);
+  }
+
+  case Expr::Sub: {
+    SubExpr *se = cast<SubExpr>(e);
+    std::string left = constructActual(se->left);
+    std::string right = constructActual(se->right);
+    return bvMinusExpr(left, right);
+  }
+
+  case Expr::Mul: {
+    MulExpr *me = cast<MulExpr>(e);
+    std::string right = constructActual(me->right);
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(me->left))
+      if (CE->getWidth() <= 64)
+        return constructMulByConstant(right, CE->getZExtValue());
+
+    std::string left = constructActual(me->left);
+    return bvMultExpr(left, right);
+  }
+
+  case Expr::UDiv: {
+    UDivExpr *de = cast<UDivExpr>(e);
+    std::string left = constructActual(de->left);
+
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(de->right)) {
+      if (CE->getWidth() <= 64) {
+        uint64_t divisor = CE->getZExtValue();
+
+        if (bits64::isPowerOfTwo(divisor)) {
+          return bvRightShift(left, bits64::indexOfSingleBit(divisor));
+        }
+      }
+    }
+
+    std::string right = constructActual(de->right);
+    return bvDivExpr(left, right);
+  }
+
+  case Expr::SDiv: {
+    SDivExpr *de = cast<SDivExpr>(e);
+    std::string left = constructActual(de->left);
+    std::string right = constructActual(de->right);
+    return sbvDivExpr(left, right);
+  }
+
+  case Expr::URem: {
+    URemExpr *de = cast<URemExpr>(e);
+    std::string left = constructActual(de->left);
+
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(de->right)) {
+      if (CE->getWidth() <= 64) {
+        uint64_t divisor = CE->getZExtValue();
+
+        if (bits64::isPowerOfTwo(divisor)) {
+          unsigned bits = bits64::indexOfSingleBit(divisor);
+
+          // special case for modding by 1 or else we bvExtract -1:0
+          if (bits == 0) {
+            return bvZero();
+          } else {
+            return bvExtract(left, bits - 1, 0);
+          }
+        }
+      }
+    }
+
+    std::string right = constructActual(de->right);
+    return bvModExpr(left, right);
+  }
+
+  case Expr::SRem: {
+    SRemExpr *de = cast<SRemExpr>(e);
+    std::string left = constructActual(de->left);
+    std::string right = constructActual(de->right);
+    return sbvModExpr(left, right);
+  }
+
+  // Bitwise
+  case Expr::Not: {
+    NotExpr *ne = cast<NotExpr>(e);
+    std::string expr = constructActual(ne->expr);
+    return notExpr(expr);
+  }
+
+  case Expr::And: {
+    AndExpr *ae = cast<AndExpr>(e);
+    std::string left = constructActual(ae->left);
+    std::string right = constructActual(ae->right);
+    return bvAndExpr(left, right);
+  }
+
+  case Expr::Or: {
+    OrExpr *oe = cast<OrExpr>(e);
+    std::string left = constructActual(oe->left);
+    std::string right = constructActual(oe->right);
+    return bvOrExpr(left, right);
+  }
+
+  case Expr::Xor: {
+    XorExpr *xe = cast<XorExpr>(e);
+    std::string left = constructActual(xe->left);
+    std::string right = constructActual(xe->right);
+    return bvXorExpr(left, right);
+  }
+
+  case Expr::Shl: {
+    ShlExpr *se = cast<ShlExpr>(e);
+    std::string left = constructActual(se->left);
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(se->right)) {
+      return bvLeftShift(left, (unsigned)CE->getLimitedValue());
+    } else {
+      std::string amount = constructActual(se->right);
+      return bvVarLeftShift(left, amount);
+    }
+  }
+
+  case Expr::LShr: {
+    LShrExpr *lse = cast<LShrExpr>(e);
+    std::string left = constructActual(lse->left);
+    if (ConstantExpr *CE = dyn_cast<ConstantExpr>(lse->right)) {
+      return bvRightShift(left, (unsigned)CE->getLimitedValue());
+    } else {
+      std::string amount = constructActual(lse->right);
+      return bvVarRightShift(left, amount);
+    }
+  }
+
+  case Expr::AShr: {
+    AShrExpr *ase = cast<AShrExpr>(e);
+    std::string left = constructActual(ase->left);
+    std::string amount = constructActual(ase->right);
+    return bvVarArithRightShift(left, amount);
+  }
+
+  // Comparison
+  case Expr::Eq: {
+    EqExpr *ee = cast<EqExpr>(e);
+    std::string left = constructActual(ee->left);
+    std::string right = constructActual(ee->right);
+    return eqExpr(left, right);
+  }
+
+  case Expr::Ult: {
+    UltExpr *ue = cast<UltExpr>(e);
+    std::string left = constructActual(ue->left);
+    std::string right = constructActual(ue->right);
+    return bvLtExpr(left, right);
+  }
+
+  case Expr::Ule: {
+    UleExpr *ue = cast<UleExpr>(e);
+    std::string left = constructActual(ue->left);
+    std::string right = constructActual(ue->right);
+    return bvLeExpr(left, right);
+  }
+
+  case Expr::Slt: {
+    SltExpr *se = cast<SltExpr>(e);
+    std::string left = constructActual(se->left);
+    std::string right = constructActual(se->right);
+    return sbvLtExpr(left, right);
+  }
+
+  case Expr::Sle: {
+    SleExpr *se = cast<SleExpr>(e);
+    std::string left = constructActual(se->left);
+    std::string right = constructActual(se->right);
+    return sbvLeExpr(left, right);
+  }
+
+  default:
+    assert(0 && "unhandled Expr type");
+    return getTrue();
+  }
+}
+std::string PrettyExpressionBuilder::construct(ref<Expr> e) {
+  PrettyExpressionBuilder *instance = new PrettyExpressionBuilder();
+  std::string ret = instance->constructActual(e);
+  delete instance;
+  return ret;
+}
+
+std::string
+PrettyExpressionBuilder::constructQuery(ConstraintManager &constraints,
+                                        ref<Expr> query) {
+  std::string msg;
+  std::string tabs = makeTabs(1);
+  llvm::raw_string_ostream stream(msg);
+  stream << "antecedent:\n";
+  for (ConstraintManager::const_iterator it = constraints.begin(),
+                                         ie = constraints.end();
+       it != ie; ++it) {
+    stream << tabs << construct(*it) << "\n";
+  }
+  stream << "consequent:\n";
+  stream << tabs << construct(query) << "\n";
+  stream.flush();
+  return msg;
+}
+
+std::string PrettyExpressionBuilder::buildArray(const char *name,
+                                                unsigned indexWidth,
+                                                unsigned valueWidth) {
+  return name;
+}
+
+std::string PrettyExpressionBuilder::getTrue() { return "true"; }
+std::string PrettyExpressionBuilder::getFalse() { return "false"; }
+std::string PrettyExpressionBuilder::getInitialRead(const Array *root,
+                                                    unsigned index) {
+  return readExpr(getInitialArray(root), bvConst32(index));
+}
+
+PrettyExpressionBuilder::PrettyExpressionBuilder() {}
+
+PrettyExpressionBuilder::~PrettyExpressionBuilder() {}
+}

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SymbolicError.h"
+#include "klee/util/PrettyExpressionBuilder.h"
 
 #include "Executor.h"
 #include "klee/CommandLine.h"


### PR DESCRIPTION
Grafted `PrettyExpressionBuilder` from Tracer-X and use it to convert KLEE's KQuery expression into a more human-readable format when outputting precision error in `*.fp_error` files.