### PR TITLE
Add special function handler to print error expression

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -80,6 +80,7 @@ extern "C" {
   
   /* print the tree associated w/ a given expression. */
   void klee_print_expr(const char *msg, ...);
+  void klee_print_error_expr(const char *msg, ...);
   
   /* NB: this *does not* fork n times and return [0,n) in children.
    * It makes n be symbolic and returns: caller must compare N times.

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1303,6 +1303,12 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
            it != ie; ++it) {
         exprArguments.push_back(it->value);
       }
+
+      for (std::vector<Cell>::iterator it = arguments.begin(),
+                                             ie = arguments.end();
+                 it != ie; ++it) {
+              exprArguments.push_back(it->error);
+      }
       // state may be destroyed by this call, cannot touch
       callExternalFunction(state, ki, f, exprArguments);
       break;

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -108,6 +108,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_prefer_cex", handlePreferCex, false),
   add("klee_posix_prefer_cex", handlePosixPreferCex, false),
   add("klee_print_expr", handlePrintExpr, false),
+  add("klee_print_error_expr", handlePrintErrorExpr, false),
   add("klee_print_range", handlePrintRange, false),
   add("klee_set_forking", handleSetForking, false),
   add("klee_stack_trace", handleStackTrace, false),
@@ -461,8 +462,8 @@ SpecialFunctionHandler::handleTrackError(ExecutionState &state,
     name = "unnamed_error";
   } else {
     // FIXME: Should be a user.err, not an assert.
-    assert(arguments.size() == 2 &&
-           "invalid number of arguments to klee_track_error");
+    /*assert(arguments.size() == 2 &&
+           "invalid number of arguments to klee_track_error");*/
     name = readStringAtAddress(state, arguments[1]);
   }
 
@@ -507,11 +508,21 @@ void SpecialFunctionHandler::handlePosixPreferCex(ExecutionState &state,
 void SpecialFunctionHandler::handlePrintExpr(ExecutionState &state,
                                   KInstruction *target,
                                   std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size()==2 &&
-         "invalid number of arguments to klee_print_expr");
+  /*assert(arguments.size()==2 &&
+         "invalid number of arguments to klee_print_expr");*/
 
   std::string msg_str = readStringAtAddress(state, arguments[0]);
   llvm::errs() << msg_str << ":" << arguments[1] << "\n";
+}
+
+void SpecialFunctionHandler::handlePrintErrorExpr(ExecutionState &state,
+                                  KInstruction *target,
+                                  std::vector<ref<Expr> > &arguments) {
+  /*assert(arguments.size()==2 &&
+         "invalid number of arguments to klee_print_expr");*/
+
+  std::string msg_str = readStringAtAddress(state, arguments[0]);
+  llvm::errs() << msg_str << ":" << arguments[3] << "\n";
 }
 
 void SpecialFunctionHandler::handleSetForking(ExecutionState &state,
@@ -746,8 +757,8 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
     name = "unnamed";
   } else {
     // FIXME: Should be a user.err, not an assert.
-    assert(arguments.size()==3 &&
-           "invalid number of arguments to klee_make_symbolic");  
+   /* assert(arguments.size()==3 &&
+           "invalid number of arguments to klee_make_symbolic"); */
     name = readStringAtAddress(state, arguments[2]);
   }
 

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -123,6 +123,7 @@ namespace klee {
     HANDLER(handlePreferCex);
     HANDLER(handlePosixPreferCex);
     HANDLER(handlePrintExpr);
+    HANDLER(handlePrintErrorExpr);
     HANDLER(handlePrintRange);
     HANDLER(handleRange);
     HANDLER(handleRealloc);

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -774,6 +774,7 @@ static const char *modelledExternals[] = {
   "klee_prefer_cex",
   "klee_posix_prefer_cex",
   "klee_print_expr",
+  "klee_print_error_expr",
   "klee_print_range",
   "klee_report_error",
   "klee_set_forking",


### PR DESCRIPTION
Add the special function handler "klee_print_error_expr" to print the error expression of a symbolic variable. 