### PR TITLE
WIP: Implemented error propagation in calls and returns

### DIFF
--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -26,6 +26,25 @@ class ErrorState {
 public:
   unsigned refCount;
 
+  class CallFrame {
+  public:
+    unsigned refCount;
+
+  private:
+    llvm::Instruction *call;
+
+    std::map<llvm::Value *, ref<Expr> > argumentErrors;
+
+  public:
+    CallFrame(llvm::Instruction *inst, std::vector<ref<Expr> > &_errors);
+
+    ~CallFrame() {}
+
+    ref<Expr> getError(llvm::Value *v) const;
+
+    llvm::Instruction *getInstruction() const { return call; }
+  };
+
 private:
   std::map<llvm::Value *, ref<Expr> > valueErrorMap;
 
@@ -39,6 +58,9 @@ private:
   std::string outputString;
 
   std::map<uintptr_t, ref<Expr> > storedError;
+
+  /// \brief This is where we store the call error values of call arguments
+  std::vector<ref<CallFrame> > callStack;
 
 public:
   ErrorState() : refCount(0) {}


### PR DESCRIPTION
@Himeshi Resolves issue #26. The problem was that the error expressions were not implemented properly in function calls and returns. It still worked without `mem2reg` since the errors were store in memory using absolute addresses. With `mem2reg`, the storing into memory at function calls and returns were skipped such that the error expressions were not propagated.

Now runs with `basic/add_test.c` and `basic/add_test2.c` should result in non-zero error expression, even when the bitcode has been processed with `mem2reg`.