### PR TITLE
Remove ErrorState::valueErrorMap

### DIFF
--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -87,9 +87,8 @@ ref<Expr> ErrorState::getError(Executor *executor, ref<Expr> valueExpr,
 
 ErrorState::~ErrorState() {}
 
-void ErrorState::outputErrorBound(llvm::Instruction *inst, double bound) {
-  ref<Expr> e = ConstantExpr::create(0, Expr::Int8);
-
+void ErrorState::outputErrorBound(llvm::Instruction *inst, ref<Expr> error,
+                                  double bound) {
   llvm::raw_string_ostream stream(outputString);
   if (!outputString.empty()) {
     stream << "\n------------------------\n";
@@ -113,7 +112,7 @@ void ErrorState::outputErrorBound(llvm::Instruction *inst, double bound) {
   }
 
   stream << "\nOutput Error: ";
-  stream << PrettyExpressionBuilder::construct(e);
+  stream << PrettyExpressionBuilder::construct(error);
   stream << "\nAbsolute Bound: " << bound << "\n";
   stream.flush();
 }

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -213,17 +213,7 @@ ref<Expr> ErrorState::propagateError(Executor *executor,
       rError = getError(executor, rValue, rOp);
     }
 
-    ref<Expr> extendedLeft = lError;
-    if (lError->getWidth() != lValue->getWidth()) {
-      extendedLeft = ZExtExpr::create(lError, lValue->getWidth());
-    }
-    ref<Expr> extendedRight = rError;
-    if (rError->getWidth() != rValue->getWidth()) {
-      extendedRight = ZExtExpr::create(rError, rValue->getWidth());
-    }
-
-    result = ExtractExpr::create(AddExpr::create(extendedLeft, extendedRight),
-                                 0, Expr::Int8);
+    result = AddExpr::create(lError, rError);
     return result;
   }
   case llvm::Instruction::FDiv:
@@ -243,17 +233,7 @@ ref<Expr> ErrorState::propagateError(Executor *executor,
       rError = getError(executor, rValue, rOp);
     }
 
-    ref<Expr> extendedLeft = lError;
-    if (lError->getWidth() != lValue->getWidth()) {
-      extendedLeft = ZExtExpr::create(lError, lValue->getWidth());
-    }
-    ref<Expr> extendedRight = rError;
-    if (rError->getWidth() != rValue->getWidth()) {
-      extendedRight = ZExtExpr::create(rError, rValue->getWidth());
-    }
-
-    result = ExtractExpr::create(AddExpr::create(extendedLeft, extendedRight),
-                                 0, Expr::Int8);
+    result = AddExpr::create(lError, rError);
     return result;
   }
   case llvm::Instruction::SDiv: {
@@ -272,17 +252,7 @@ ref<Expr> ErrorState::propagateError(Executor *executor,
       rError = getError(executor, rValue, rOp);
     }
 
-    ref<Expr> extendedLeft = lError;
-    if (lError->getWidth() != lValue->getWidth()) {
-      extendedLeft = ZExtExpr::create(lError, lValue->getWidth());
-    }
-    ref<Expr> extendedRight = rError;
-    if (rError->getWidth() != rValue->getWidth()) {
-      extendedRight = ZExtExpr::create(rError, rValue->getWidth());
-    }
-
-    result = ExtractExpr::create(AddExpr::create(extendedLeft, extendedRight),
-                                 0, Expr::Int8);
+    result = AddExpr::create(lError, rError);
     return result;
   }
   case llvm::Instruction::GetElementPtr: {

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -28,8 +28,6 @@ public:
   unsigned refCount;
 
 private:
-  std::map<llvm::Value *, ref<Expr> > valueErrorMap;
-
   std::map<const Array *, const Array *> arrayErrorArrayMap;
 
   ref<Expr> getError(Executor *executor, ref<Expr> valueExpr,
@@ -46,8 +44,6 @@ public:
 
   ErrorState(ErrorState &symErr) : refCount(0) {
     storedError = symErr.storedError;
-    // FIXME: Simple copy for now.
-    valueErrorMap = symErr.valueErrorMap;
   }
 
   ~ErrorState();
@@ -56,8 +52,6 @@ public:
 
   ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
                            ref<Expr> result, std::vector<Cell> &arguments);
-
-  ref<Expr> retrieveError(llvm::Value *value) { return valueErrorMap[value]; }
 
   std::string &getOutputString() { return outputString; }
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -48,7 +48,7 @@ public:
 
   ~ErrorState();
 
-  void outputErrorBound(llvm::Instruction *inst, double bound);
+  void outputErrorBound(llvm::Instruction *inst, ref<Expr> error, double bound);
 
   ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
                            ref<Expr> result, std::vector<Cell> &arguments);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1825,6 +1825,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     Value *fp = cs.getCalledValue();
     Function *f = getTargetFunction(fp, state);
 
+    if (f->getName().str() == "klee_bound_error") {
+      ref<Expr> error = eval(ki, 1, state).error;
+      state.symbolicError->setKleeBoundErrorExpr(error);
+    }
+
     // Skip debug intrinsics, we can't evaluate their metadata arguments.
     if (f && isDebugIntrinsic(f, kmodule))
       break;

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -154,10 +154,7 @@ bool SymbolicError::breakLoop(Executor *executor, ExecutionState &state,
                  it1 = phiResultInitErrorStackElem.begin(),
                  ie1 = phiResultInitErrorStackElem.end();
              it1 != ie1; ++it1) {
-          ref<Expr> error = errorState->retrieveError(it1->first->inst);
-          if (error.isNull()) {
-            error = ConstantExpr::create(0, Expr::Int8);
-          }
+          ref<Expr> error = it1->second;
 
           // We store the computed error amount to be used outside the loop, and
           // store it

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -101,10 +101,6 @@ public:
                            ref<Expr> result, std::vector<Cell> &arguments,
                            unsigned int phiResultWidth = 0);
 
-  ref<Expr> retrieveError(llvm::Value *value) {
-    return errorState->retrieveError(value);
-  }
-
   bool checkStoredError(ref<Expr> address) {
     return errorState->hasStoredError(address);
   }

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -54,6 +54,10 @@ class SymbolicError {
   /// \brief Temporary PHI result initial error amount
   std::map<KInstruction *, ref<Expr> > tmpPhiResultInitError;
 
+  /// \brief Temporary storage to store the error expression for
+  /// klee_bound_error call
+  ref<Expr> kleeBoundErrorExpr;
+
 public:
   SymbolicError() { errorState = ref<ErrorState>(new ErrorState()); }
 
@@ -94,7 +98,7 @@ public:
                               llvm::Instruction *inst);
 
   void outputErrorBound(llvm::Instruction *inst, double bound) {
-    errorState->outputErrorBound(inst, bound);
+    errorState->outputErrorBound(inst, kleeBoundErrorExpr, bound);
   }
 
   ref<Expr> propagateError(Executor *executor, KInstruction *ki,
@@ -121,6 +125,8 @@ public:
   ref<Expr> executeLoad(llvm::Value *value, ref<Expr> address) {
     return errorState->executeLoad(value, address);
   }
+
+  void setKleeBoundErrorExpr(ref<Expr> error) { kleeBoundErrorExpr = error; }
 
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;


### PR DESCRIPTION
Resolves issue #33, confirming that it is possible.

In addition, this PR also simplifies and corrected the handling of multiplication and division in `ErrorState::propagateError()`. Previously assertion may be triggered due to unequal widths in the creation of `AddExpr` (call to `AddExpr::create()`).