### PR TITLE
Path probability implementation

### DIFF
--- a/include/klee/Internal/Module/EdgeProbability.h
+++ b/include/klee/Internal/Module/EdgeProbability.h
@@ -1,0 +1,57 @@
+//===------- EdgeProbability.h --------------------------------------------===//
+//
+// The KLEE Symbolic Virtual Machine with Numerical Error Analysis Extension
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef EDGEPROBABILITY_H_
+#define EDGEPROBABILITY_H_
+
+#include "klee/Config/Version.h"
+
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Analysis/BranchProbabilityInfo.h"
+#if LLVM_VERSION_CODE > LLVM_VERSION(3, 2)
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Instruction.h"
+#else
+#include "llvm/Module.h"
+#include "llvm/Function.h"
+#include "llvm/Instructions.h"
+#include "llvm/Instruction.h"
+#endif
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include <map>
+
+namespace klee {
+
+class EdgeProbability : public llvm::ModulePass {
+
+  std::map<llvm::BasicBlock *, std::pair<llvm::BasicBlock *, double> >
+  edgeProbability;
+
+public:
+  static char ID;
+
+  static EdgeProbability *instance;
+
+  EdgeProbability() : ModulePass(ID) {}
+
+  virtual bool runOnModule(llvm::Module &M);
+
+  virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
+
+  double getEdgeProbability(llvm::BasicBlock *dst, llvm::BasicBlock *src) const;
+};
+}
+
+#endif /* EDGEPROBABILITY_H_ */

--- a/lib/Core/EdgeProbability.cpp
+++ b/lib/Core/EdgeProbability.cpp
@@ -1,0 +1,88 @@
+//===------- EdgeProbability.cpp ------------------------------------------===//
+//
+// The KLEE Symbolic Virtual Machine with Numerical Error Analysis Extension
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../../include/klee/Internal/Module/EdgeProbability.h"
+
+#define DEBUG_TYPE "edge-probability"
+
+#include "llvm/DebugInfo.h"
+#include "llvm/Pass.h"
+
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/PassManager.h"
+#include "llvm/Analysis/BranchProbabilityInfo.h"
+#if LLVM_VERSION_CODE > LLVM_VERSION(3, 2)
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Instruction.h"
+#else
+#include "llvm/Module.h"
+#include "llvm/Function.h"
+#include "llvm/Instructions.h"
+#include "llvm/Instruction.h"
+#endif
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include <set>
+#include <vector>
+
+using namespace klee;
+
+bool EdgeProbability::runOnModule(llvm::Module &M) {
+  for (llvm::Module::iterator func = M.begin(), fe = M.end(); func != fe;
+       ++func) {
+    if (func->isDeclaration())
+      continue;
+
+    const llvm::BranchProbabilityInfo &BPI =
+        getAnalysis<llvm::BranchProbabilityInfo>(*func);
+
+    for (llvm::Function::iterator bi = func->begin(), be = func->end();
+         bi != be; ++bi) {
+      llvm::TerminatorInst *ti = bi->getTerminator();
+      unsigned numSuccessors = ti->getNumSuccessors();
+      for (unsigned i = 0; i < numSuccessors; ++i) {
+        llvm::BasicBlock *succ = ti->getSuccessor(i);
+        llvm::BranchProbability prob = BPI.getEdgeProbability(&(*bi), i);
+        double floatProb =
+            ((double)prob.getNumerator()) / ((double)prob.getDenominator());
+        edgeProbability[&(*bi)] =
+            std::pair<llvm::BasicBlock *, double>(succ, floatProb);
+      }
+    }
+  }
+
+  return false; // does not modify program
+}
+
+void EdgeProbability::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+  AU.setPreservesAll();
+  AU.addRequired<llvm::BranchProbabilityInfo>();
+}
+
+double EdgeProbability::getEdgeProbability(llvm::BasicBlock *dst,
+                                           llvm::BasicBlock *src) const {
+  std::map<llvm::BasicBlock *,
+           std::pair<llvm::BasicBlock *, double> >::const_iterator it =
+      edgeProbability.find(src);
+  if (it != edgeProbability.end()) {
+    return it->second.second;
+  }
+  return 0;
+}
+
+char EdgeProbability::ID = 0;
+EdgeProbability *EdgeProbability::instance = 0;
+
+static llvm::RegisterPass<EdgeProbability> X("edge-probability",
+                                             "Extract CFG edge probability");

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1507,6 +1507,9 @@ void Executor::transferToBasicBlock(BasicBlock *dst, BasicBlock *src,
     PHINode *first = static_cast<PHINode*>(state.pc->inst);
     state.incomingBBIndex = first->getBasicBlockIndex(src);
   }
+
+  if (PrecisionError)
+    state.symbolicError->recomputePathProbability(dst, src);
 }
 
 /// Compute the true target of a function call, resolving LLVM and KLEE aliases

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Pass.h"
 #include "llvm/PassManager.h"
 
+#include "../../include/klee/Internal/Module/EdgeProbability.h"
 #include "../../include/klee/Internal/Module/TripCounter.h"
 #if LLVM_VERSION_CODE > LLVM_VERSION(3, 2)
 #include "llvm/IR/Constants.h"
@@ -1418,6 +1419,9 @@ int main(int argc, char **argv, char **envp) {
   llvm::PassManager PM;
   TripCounter::instance = new TripCounter();
   PM.add(TripCounter::instance);
+  PM.add(new llvm::BranchProbabilityInfo());
+  EdgeProbability::instance = new EdgeProbability();
+  PM.add(EdgeProbability::instance);
   PM.run(*analysisModule);
 
   const Module *finalModule = analysisModule;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -496,6 +496,13 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete f;
     }
 
+    double pathProbability = state.symbolicError->getPathProbability();
+    if (pathProbability > 0) {
+      llvm::raw_ostream *probFile = openTestFile("prob", id);
+      *probFile << pathProbability;
+      delete probFile;
+    }
+
     if (errorMessage || WriteKQueries) {
       std::string constraints;
       m_interpreter->getConstraintLog(state, constraints,Interpreter::KQUERY);


### PR DESCRIPTION
For every test `testN.ktest`, `testN.prob` is also generated, containing the probability of the test path being executed.