### PR TITLE
Added support for outputing line numbers visited by a path in test*.l…

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -73,6 +73,8 @@ extern llvm::cl::opt<bool> DebugPrecision;
 
 extern llvm::cl::opt<bool> LoopBreaking;
 
+extern llvm::cl::opt<bool> LineNumbers;
+
 #ifdef ENABLE_METASMT
 
 enum MetaSMTBackendType

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -114,8 +114,14 @@ llvm::cl::opt<bool> LoopBreaking(
     llvm::cl::init(false));
 
 llvm::cl::opt<bool>
-    UseAssignmentValidatingSolver("debug-assignment-validating-solver",
-                                  llvm::cl::init(false));
+LineNumbers("line-numbers",
+            llvm::cl::desc(
+                "Enable output of visited line numbers in test*.lines files"),
+            llvm::cl::init(false));
+
+llvm::cl::opt<bool>
+UseAssignmentValidatingSolver("debug-assignment-validating-solver",
+                              llvm::cl::init(false));
 
 #ifdef ENABLE_METASMT
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1573,6 +1573,10 @@ static inline const llvm::fltSemantics * fpWidthToSemantics(unsigned width) {
 
 void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
   Instruction *i = ki->inst;
+
+  if (LineNumbers)
+    state.symbolicError->addLineNumber(i);
+
   switch (i->getOpcode()) {
     // Control flow
   case Instruction::Ret: {

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -63,6 +63,9 @@ class SymbolicError {
   /// \brief The path probability
   double pathProbability;
 
+  /// \brief Path line numbers
+  std::vector<std::pair<std::string, unsigned> > lineNumbers;
+
 public:
   SymbolicError() : pathProbability(-1.0) {
     errorState = ref<ErrorState>(new ErrorState());
@@ -75,7 +78,8 @@ public:
         phiResultWidthList(symErr.phiResultWidthList),
         phiResultInitErrorStack(symErr.phiResultInitErrorStack),
         tmpPhiResultInitError(symErr.tmpPhiResultInitError),
-        pathProbability(symErr.pathProbability) {}
+        pathProbability(symErr.pathProbability),
+        lineNumbers(symErr.lineNumbers) {}
 
   ~SymbolicError();
 
@@ -156,6 +160,12 @@ public:
   }
 
   double getPathProbability() const { return pathProbability; }
+
+  void addLineNumber(llvm::Instruction *i);
+
+  const std::vector<std::pair<std::string, unsigned> > &getLineNumbers() const {
+    return lineNumbers;
+  }
 
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -503,6 +503,24 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete probFile;
     }
 
+    const std::vector<std::pair<std::string, unsigned> > &lineNumbers(
+        state.symbolicError->getLineNumbers());
+    if (lineNumbers.size() > 0) {
+      llvm::raw_ostream *linesFile = openTestFile("lines", id);
+      std::string currentFile = "";
+      for (std::vector<std::pair<std::string, unsigned> >::const_iterator
+               it = lineNumbers.begin(),
+               ie = lineNumbers.end();
+           it != ie; ++it) {
+        if (currentFile != it->first) {
+          *linesFile << "File: " << it->first << "\n";
+          currentFile = it->first;
+        }
+        *linesFile << it->second << "\n";
+      }
+      delete linesFile;
+    }
+
     if (errorMessage || WriteKQueries) {
       std::string constraints;
       m_interpreter->getConstraintLog(state, constraints,Interpreter::KQUERY);


### PR DESCRIPTION
…ines file.

Use --line-numbers to activate.

* Added SymbolicError::lineNumbers member variable,
* Added SymbolicError::addLineNumber() and SymbolicError::getLineNumbers() member functions
* Added outputting the line numbers into test*.lines file in KLEE's main.cpp

Resolves #48.