### PR TITLE
Fixed the computation of path probability in SymbolicError::recompute…

### DIFF
--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -152,7 +152,7 @@ public:
       pathProbability = EdgeProbability::instance->getEdgeProbability(dst, src);
       return;
     }
-    pathProbability = EdgeProbability::instance->getEdgeProbability(dst, src);
+    pathProbability += EdgeProbability::instance->getEdgeProbability(dst, src);
   }
 
   double getPathProbability() const { return pathProbability; }


### PR DESCRIPTION
…PathProbability(). The old computation was actually an error. The new computation sums up all the branch probabilities along an execution path. This resolves issue #49.