### PR TITLE
Implementation of path scoring based more/less probable edges count

### DIFF
--- a/include/klee/Internal/Module/EdgeProbability.h
+++ b/include/klee/Internal/Module/EdgeProbability.h
@@ -50,7 +50,8 @@ public:
 
   virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
 
-  double getEdgeProbability(llvm::BasicBlock *dst, llvm::BasicBlock *src) const;
+  bool hasWinningProbability(llvm::BasicBlock *dst,
+                             llvm::BasicBlock *src) const;
 };
 }
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -60,11 +60,11 @@ class SymbolicError {
   /// klee_bound_error call
   ref<Expr> kleeBoundErrorExpr;
 
-  /// \brief The path probability flag
-  bool winningPath;
+  /// \brief How many times the edge with less probability taken
+  uint64_t lostBranchTakenCount;
 
 public:
-  SymbolicError() : winningPath(true) {
+  SymbolicError() : lostBranchTakenCount(0) {
     errorState = ref<ErrorState>(new ErrorState());
   }
 
@@ -75,7 +75,7 @@ public:
         phiResultWidthList(symErr.phiResultWidthList),
         phiResultInitErrorStack(symErr.phiResultInitErrorStack),
         tmpPhiResultInitError(symErr.tmpPhiResultInitError),
-        winningPath(symErr.winningPath) {}
+        lostBranchTakenCount(symErr.lostBranchTakenCount) {}
 
   ~SymbolicError();
 
@@ -149,10 +149,10 @@ public:
 
   void recomputePathProbability(llvm::BasicBlock *dst, llvm::BasicBlock *src) {
     if (!EdgeProbability::instance->hasWinningProbability(dst, src))
-      winningPath = false;
+      lostBranchTakenCount++;
   }
 
-  bool isWinningPath() const { return winningPath; }
+  uint64_t getLostBranchTakenCount() const { return lostBranchTakenCount; }
 
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -60,11 +60,11 @@ class SymbolicError {
   /// klee_bound_error call
   ref<Expr> kleeBoundErrorExpr;
 
-  /// \brief The path probability
-  double pathProbability;
+  /// \brief The path probability flag
+  bool winningPath;
 
 public:
-  SymbolicError() : pathProbability(-1.0) {
+  SymbolicError() : winningPath(true) {
     errorState = ref<ErrorState>(new ErrorState());
   }
 
@@ -75,7 +75,7 @@ public:
         phiResultWidthList(symErr.phiResultWidthList),
         phiResultInitErrorStack(symErr.phiResultInitErrorStack),
         tmpPhiResultInitError(symErr.tmpPhiResultInitError),
-        pathProbability(symErr.pathProbability) {}
+        winningPath(symErr.winningPath) {}
 
   ~SymbolicError();
 
@@ -148,14 +148,11 @@ public:
   void setKleeBoundErrorExpr(ref<Expr> error) { kleeBoundErrorExpr = error; }
 
   void recomputePathProbability(llvm::BasicBlock *dst, llvm::BasicBlock *src) {
-    if (pathProbability < 0) {
-      pathProbability = EdgeProbability::instance->getEdgeProbability(dst, src);
-      return;
-    }
-    pathProbability += EdgeProbability::instance->getEdgeProbability(dst, src);
+    if (!EdgeProbability::instance->hasWinningProbability(dst, src))
+      winningPath = false;
   }
 
-  double getPathProbability() const { return pathProbability; }
+  bool isWinningPath() const { return winningPath; }
 
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -496,11 +496,11 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete f;
     }
 
-    bool winningPath = state.symbolicError->isWinningPath();
-    if (winningPath) {
-      llvm::raw_ostream *choicePathFile = openTestFile("choice", id);
-      *choicePathFile << 1;
-      delete choicePathFile;
+    uint64_t improbability = state.symbolicError->getLostBranchTakenCount();
+    {
+      llvm::raw_ostream *improbabilityFile = openTestFile("improb", id);
+      *improbabilityFile << improbability << "\n";
+      delete improbabilityFile;
     }
 
     if (errorMessage || WriteKQueries) {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -496,11 +496,11 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete f;
     }
 
-    double pathProbability = state.symbolicError->getPathProbability();
-    if (pathProbability > 0) {
-      llvm::raw_ostream *probFile = openTestFile("prob", id);
-      *probFile << pathProbability;
-      delete probFile;
+    bool winningPath = state.symbolicError->isWinningPath();
+    if (winningPath) {
+      llvm::raw_ostream *choicePathFile = openTestFile("choice", id);
+      *choicePathFile << 1;
+      delete choicePathFile;
     }
 
     if (errorMessage || WriteKQueries) {


### PR DESCRIPTION
… better probability in each branch point

* The path selection is to be used for sensitivity analysis
* The chosen path will have `test<N>.choice` file generated for it

@Himeshi I think this implementation implements the selection criteria that we want: We select the path that always has better execution probability at every branch point.