### PR TITLE
Symbolic index fix

### DIFF
--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -45,8 +45,6 @@ public:
 
   void addConstraint(ref<Expr> e);
 
-  void addErrorConstraint(ref<Expr> e);
-
   bool empty() const {
     return constraints.empty();
   }

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -169,10 +169,7 @@ public:
   void popFrame();
 
   void addSymbolic(const MemoryObject *mo, const Array *array);
-  void addConstraint(ref<Expr> e, ref<Expr> error) {
-    constraints.addConstraint(e);
-    symbolicError->addErrorConstraint(error);
-  }
+  void addConstraint(ref<Expr> e) { constraints.addConstraint(e); }
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -486,11 +486,10 @@ void ErrorState::executeStoreSimple(ref<Expr> address, ref<Expr> error) {
   // At store instruction, we store new error by a multiply of the stored error
   // with the loop trip count.
   if (ConstantExpr *cp = llvm::dyn_cast<ConstantExpr>(address)) {
+	// We only store the error of concrete addresses
     uint64_t intAddress = cp->getZExtValue();
     storedError[intAddress] = error;
-    return;
   }
-  assert(!"non-constant address");
 }
 
 void ErrorState::declareInputError(ref<Expr> address, ref<Expr> error) {

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -655,15 +655,6 @@ ref<Expr> ErrorState::executeLoad(llvm::Value *addressValue, ref<Expr> base,
   return error;
 }
 
-void ErrorState::overwriteWith(ref<ErrorState> overwriting) {
-  for (std::map<uintptr_t, ref<Expr> >::iterator
-           it = overwriting->storedError.begin(),
-           ie = overwriting->storedError.end();
-       it != ie; ++it) {
-    storedError[it->first] = it->second;
-  }
-}
-
 void ErrorState::print(llvm::raw_ostream &os) const {
   os << "Array->Error Array:\n";
   for (std::map<const Array *, const Array *>::const_iterator

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -83,9 +83,6 @@ public:
   ref<Expr> executeLoad(llvm::Value *value, ref<Expr> base, ref<Expr> address,
                         ref<Expr> offset);
 
-  /// \brief Overwrite the contents of the current error state with another
-  void overwriteWith(ref<ErrorState> overwriting);
-
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -63,8 +63,10 @@ public:
                                      double bound, std::string name,
                                      std::vector<ref<Expr> > &_inputErrorList);
 
-  ref<Expr> propagateError(Executor *executor, llvm::Instruction *instr,
-                           ref<Expr> result, std::vector<Cell> &arguments);
+  std::pair<ref<Expr>, ref<Expr> > propagateError(Executor *executor,
+                                                  llvm::Instruction *instr,
+                                                  ref<Expr> result,
+                                                  std::vector<Cell> &arguments);
 
   std::string &getOutputString() { return outputString; }
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -80,6 +80,8 @@ public:
 
   bool hasStoredError(ref<Expr> address) const;
 
+  /// \brief Retrieve the error expression from the stored error expressions
+  /// map. This returns 0 when the address is not found.
   ref<Expr> executeLoad(llvm::Value *value, ref<Expr> base, ref<Expr> address,
                         ref<Expr> offset);
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -779,8 +779,7 @@ void Executor::branch(ExecutionState &state,
 
   for (unsigned i=0; i<N; ++i)
     if (result[i])
-      addConstraint(*result[i], conditions[i],
-                    ConstantExpr::create(0, Expr::Int8));
+      addConstraint(*result[i], conditions[i]);
 }
 
 Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
@@ -812,7 +811,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       bool success = solver->getValue(current, condition, value);
       assert(success && "FIXME: Unhandled solver failure");
       (void) success;
-      addConstraint(current, EqExpr::create(value, condition), error);
+      addConstraint(current, EqExpr::create(value, condition));
       condition = value;
     }
   }
@@ -843,10 +842,10 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
         // add constraints
         if(branch) {
           res = Solver::True;
-          addConstraint(current, condition, error);
+          addConstraint(current, condition);
         } else  {
           res = Solver::False;
-          addConstraint(current, Expr::createIsZero(condition), error);
+          addConstraint(current, Expr::createIsZero(condition));
         }
       }
     } else if (res==Solver::Unknown) {
@@ -868,10 +867,10 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
 
         TimerStatIncrementer timer(stats::forkTime);
         if (theRNG.getBool()) {
-          addConstraint(current, condition, error);
+          addConstraint(current, condition);
           res = Solver::True;        
         } else {
-          addConstraint(current, Expr::createIsZero(condition), error);
+          addConstraint(current, Expr::createIsZero(condition));
           res = Solver::False;
         }
       }
@@ -904,8 +903,8 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       assert(trueSeed || falseSeed);
       
       res = trueSeed ? Solver::True : Solver::False;
-      addConstraint(
-          current, trueSeed ? condition : Expr::createIsZero(condition), error);
+      addConstraint(current,
+                    trueSeed ? condition : Expr::createIsZero(condition));
     }
   }
 
@@ -999,9 +998,8 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       }
     }
 
-    addConstraint(*trueState, condition, error);
-    addConstraint(*falseState, Expr::createIsZero(condition),
-                  Expr::createIsZero(error));
+    addConstraint(*trueState, condition);
+    addConstraint(*falseState, Expr::createIsZero(condition));
 
     // Kinda gross, do we even really still want this option?
     if (MaxDepth && MaxDepth<=trueState->depth) {
@@ -1014,8 +1012,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
   }
 }
 
-void Executor::addConstraint(ExecutionState &state, ref<Expr> condition,
-                             ref<Expr> error) {
+void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(condition)) {
     if (!CE->isTrue())
       llvm::report_fatal_error("attempt to add invalid constraint");
@@ -1043,7 +1040,7 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition,
       klee_warning("seeds patched for violating constraint"); 
   }
 
-  state.addConstraint(condition, error);
+  state.addConstraint(condition);
   if (ivcEnabled)
     doImpliedValueConcretization(state, condition, 
                                  ConstantExpr::alloc(1, Expr::Bool));
@@ -1200,8 +1197,7 @@ Executor::toConstant(ExecutionState &state,
   else
     klee_warning_once(reason, "%s", os.str().c_str());
 
-  addConstraint(state, EqExpr::create(e, value),
-                ConstantExpr::create(0, Expr::Int8));
+  addConstraint(state, EqExpr::create(e, value));
 
   return value;
 }
@@ -3944,7 +3940,7 @@ ref<Expr> Executor::replaceReadWithSymbolic(ExecutionState &state,
   ref<Expr> res = Expr::createTempRead(array, e->getWidth());
   ref<Expr> eq = NotOptimizedExpr::create(EqExpr::create(e, res));
   llvm::errs() << "Making symbolic: " << eq << "\n";
-  state.addConstraint(eq, ConstantExpr::create(0, Expr::Int8));
+  state.addConstraint(eq);
   return res;
 }
 
@@ -4569,7 +4565,7 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
       // If the particular constraint operated on in this iteration through
       // the loop isn't implied then add it to the list of constraints.
       if (!mustBeTrue)
-        tmp.addConstraint(*pi, ConstantExpr::create(0, Expr::Int8));
+        tmp.addConstraint(*pi);
     }
     if (pi!=pie) break;
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1000,6 +1000,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
 
     addConstraint(*trueState, condition);
     addConstraint(*falseState, Expr::createIsZero(condition));
+    falseState->symbolicError->negateTopConstraint();
 
     // Kinda gross, do we even really still want this option?
     if (MaxDepth && MaxDepth<=trueState->depth) {

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -335,8 +335,7 @@ private:
   /// function is a wrapper around the state's addConstraint function
   /// which also manages propagation of implied values,
   /// validity checks, and seed patching.
-  void addConstraint(ExecutionState &state, ref<Expr> condition,
-                     ref<Expr> error);
+  void addConstraint(ExecutionState &state, ref<Expr> condition);
 
   // Called on [for now] concrete reads, replaces constant with a symbolic
   // Used for testing.

--- a/lib/Core/SeedInfo.cpp
+++ b/lib/Core/SeedInfo.cpp
@@ -63,7 +63,7 @@ void SeedInfo::patchSeed(const ExecutionState &state,
   std::vector< ref<Expr> > required(state.constraints.begin(),
                                     state.constraints.end());
   ExecutionState tmp(required);
-  tmp.addConstraint(condition, ConstantExpr::create(0, Expr::Int8));
+  tmp.addConstraint(condition);
 
   // Try and patch direct reads first, this is likely to resolve the
   // problem quickly and avoids long traversal of all seed
@@ -105,11 +105,10 @@ void SeedInfo::patchSeed(const ExecutionState &state,
         assert(success && "FIXME: Unhandled solver failure");            
         (void) success;
         it2->second[i] = value->getZExtValue(8);
-        tmp.addConstraint(EqExpr::create(read, ConstantExpr::alloc(
-                                                   it2->second[i], Expr::Int8)),
-                          ConstantExpr::create(0, Expr::Int8));
+        tmp.addConstraint(EqExpr::create(
+            read, ConstantExpr::alloc(it2->second[i], Expr::Int8)));
       } else {
-        tmp.addConstraint(isSeed, ConstantExpr::create(0, Expr::Int8));
+        tmp.addConstraint(isSeed);
       }
     }
   }
@@ -142,11 +141,10 @@ void SeedInfo::patchSeed(const ExecutionState &state,
         assert(success && "FIXME: Unhandled solver failure");            
         (void) success;
         it->second[i] = value->getZExtValue(8);
-        tmp.addConstraint(EqExpr::create(read, ConstantExpr::alloc(
-                                                   it->second[i], Expr::Int8)),
-                          ConstantExpr::create(0, Expr::Int8));
+        tmp.addConstraint(EqExpr::create(
+            read, ConstantExpr::alloc(it->second[i], Expr::Int8)));
       } else {
-        tmp.addConstraint(isSeed, ConstantExpr::create(0, Expr::Int8));
+        tmp.addConstraint(isSeed);
       }
     }
   }

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -416,7 +416,7 @@ void SpecialFunctionHandler::handleAssume(ExecutionState &state,
                                      Executor::User);
     }
   } else {
-    executor.addConstraint(state, e, ConstantExpr::create(0, Expr::Int8));
+    executor.addConstraint(state, e);
   }
 }
 

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -220,7 +220,7 @@ ref<Expr> SymbolicError::propagateError(Executor *executor, KInstruction *ki,
                                         ref<Expr> result,
                                         std::vector<Cell> &arguments,
                                         unsigned int phiResultWidth) {
-  ref<Expr> error =
+  std::pair<ref<Expr>, ref<Expr> > error =
       errorState->propagateError(executor, ki->inst, result, arguments);
 
   if (LoopBreaking) {
@@ -236,10 +236,14 @@ ref<Expr> SymbolicError::propagateError(Executor *executor, KInstruction *ki,
       if (phiResultWidthList.find(ki) == phiResultWidthList.end()) {
         phiResultWidthList[ki] = phiResultWidth;
       }
-      tmpPhiResultInitError[ki] = error;
+      tmpPhiResultInitError[ki] = error.first;
     }
   }
-  return error;
+
+  if (!error.second.isNull()) {
+    constraintsWithError.addConstraint(error.second);
+  }
+  return error.first;
 }
 
 SymbolicError::~SymbolicError() {

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -241,7 +241,7 @@ ref<Expr> SymbolicError::propagateError(Executor *executor, KInstruction *ki,
   }
 
   if (!error.second.isNull()) {
-    constraintsWithError.addConstraint(error.second);
+    constraintsWithError.push_back(error.second);
   }
   return error.first;
 }

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -82,6 +82,7 @@ public:
         phiResultWidthList(symErr.phiResultWidthList),
         phiResultInitErrorStack(symErr.phiResultInitErrorStack),
         tmpPhiResultInitError(symErr.tmpPhiResultInitError),
+        constraintsWithError(symErr.constraintsWithError),
         pathProbability(symErr.pathProbability),
         branchCount(symErr.branchCount) {}
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -62,7 +62,7 @@ class SymbolicError {
   ref<Expr> kleeBoundErrorExpr;
 
   /// \brief Contains the path conditions with propagated error
-  ConstraintManager constraintsWithError;
+  std::vector<ref<Expr> > constraintsWithError;
 
   /// \brief The path probability
   double pathProbability;
@@ -168,10 +168,12 @@ public:
 
   double getBranchCount() const { return branchCount; }
 
-  ConstraintManager getConstraintsWithError() { return constraintsWithError; }
+  std::vector<ref<Expr> > &getConstraintsWithError() {
+    return constraintsWithError;
+  }
 
   void addErrorConstraint(ref<Expr> error) {
-    constraintsWithError.addErrorConstraint(error);
+    constraintsWithError.push_back(error);
   }
 
   /// print - Print the object content to stream

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -176,6 +176,16 @@ public:
     constraintsWithError.push_back(error);
   }
 
+  void negateTopConstraint() {
+    if (!constraintsWithError.size())
+      return;
+
+    ref<Expr> constraint = constraintsWithError.back();
+    constraintsWithError.pop_back();
+
+    constraintsWithError.push_back(Expr::createIsZero(constraint));
+  }
+
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;
 

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -165,10 +165,6 @@ void ConstraintManager::addConstraintInternal(ref<Expr> e) {
   }
 }
 
-void ConstraintManager::addErrorConstraint(ref<Expr> e) {
-  constraints.push_back(e);
-}
-
 void ConstraintManager::addConstraint(ref<Expr> e) {
   e = simplifyExpr(e);
   addConstraintInternal(e);

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -509,11 +509,12 @@ void KleeHandler::processTestCase(const ExecutionState &state,
 
     if (PrecisionError) {
       llvm::raw_ostream *f = openTestFile("kquery_precision_error", id);
-      ConstraintManager constraintsWithError =
+      std::vector<ref<Expr> > &constraintsWithError =
           state.symbolicError->getConstraintsWithError();
       *f << "Path conditions with error:";
-      for (ConstraintManager::const_iterator it = constraintsWithError.begin(),
-                                             ie = constraintsWithError.end();
+      for (std::vector<ref<Expr> >::const_iterator
+               it = constraintsWithError.begin(),
+               ie = constraintsWithError.end();
            it != ie; ++it) {
         if (it != constraintsWithError.begin())
           *f << " && " << PrettyExpressionBuilder::construct(*it);


### PR DESCRIPTION
Fixes crashes due to symbolic index. This is done by assuming that retrieved error for symbolic indices is 0, as it can be assumed that the value is non-approximable in that case.

Secondly, this also fixes crashes due to mismatched type returned by ErrorState::propagateError(), which sometimes returns Boolean expression, from the construction of path condition constraint with error, when the expected return type is 8-bits. The path condition constraint with error is now separated from the actual error value (which is 0 in case of conditional). ErrorState::propagateError() has been made to return a pair of them.

Tested on `get_sign.c`, same output before and after this patch:
```
#include <klee/klee.h>

int calculate_output(int x, int y)
{
    int z;

    if (x < 5) {
        z = x + y;
    } else {
        z = x * y;
    }
    return z;
}

int main()
{
    int output;
    int input_x, input_y;
    
    klee_make_symbolic(&input_x, sizeof(input_x), "input_x");
    klee_make_symbolic(&input_y, sizeof(input_y), "input_y");

    klee_track_error(&input_x, "input_x_error");
    klee_track_error(&input_y, "input_y_error");
 
    output = calculate_output(input_x, input_y);

    klee_bound_error(output, "output", 1.3);

    return 0;
}
```