### PR TITLE
Non-approximable symbolic index

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -73,6 +73,8 @@ extern llvm::cl::opt<bool> DebugPrecision;
 
 extern llvm::cl::opt<bool> LoopBreaking;
 
+extern llvm::cl::opt<bool> ApproximableAddress;
+
 #ifdef ENABLE_METASMT
 
 enum MetaSMTBackendType

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -113,6 +113,12 @@ llvm::cl::opt<bool> LoopBreaking(
         "Enable loop breaking: effective only when -precision is specified"),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> ApproximableAddress(
+    "approximable-address",
+    llvm::cl::desc("Assumes addresses are approximable: never constrains "
+                   "errors of addresses in load/store operations to zero."),
+    llvm::cl::init(false));
+
 llvm::cl::opt<bool>
     UseAssignmentValidatingSolver("debug-assignment-validating-solver",
                                   llvm::cl::init(false));

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -502,11 +502,91 @@ ErrorState::propagateError(Executor *executor, KInstruction *ki,
           ConstantExpr::create(0, Expr::Int8), nullExpr);
   }
   case llvm::Instruction::GetElementPtr: {
-    ref<Expr> error = arguments.at(0).error;
+    Cell oldBaseCell = arguments.at(0);
+    ref<Expr> base = oldBaseCell.value;
+    ref<Expr> error = oldBaseCell.error;
+    ref<Expr> errorConstraint;
+
+    KGEPInstruction *kgepi = static_cast<KGEPInstruction *>(ki);
+    unsigned i = 1;
+    for (std::vector<std::pair<unsigned, uint64_t> >::iterator
+             it = kgepi->indices.begin(),
+             ie = kgepi->indices.end();
+         it != ie; ++it) {
+      uint64_t elementSize = it->second;
+      Cell c = arguments.at(i);
+      llvm::Value *indexValue = instr->getOperand(i);
+      ref<Expr> index = c.value;
+      ref<Expr> indexError = c.error;
+      ref<Expr> mulRValue = Expr::createPointer(elementSize);
+
+      if (indexError.isNull()) {
+        indexError = getError(executor, index, indexValue);
+      }
+
+      if (!ApproximableAddress && !llvm::isa<ConstantExpr>(indexError)) {
+        ref<Expr> indexErrorConstraint =
+            EqExpr::create(ConstantExpr::create(0, Expr::Int8), indexError);
+        if (errorConstraint.isNull()) {
+          errorConstraint = indexErrorConstraint;
+        } else {
+          errorConstraint =
+              AndExpr::create(errorConstraint, indexErrorConstraint);
+        }
+      }
+
+      ref<Expr> lError = error;
+      ref<Expr> lValue = base;
+      ref<Expr> rError = indexError;
+      ref<Expr> rValue =
+          MulExpr::create(Expr::createSExtToPointerWidth(index), mulRValue);
+
+      base = AddExpr::create(base, rValue);
+
+      ref<Expr> extendedLeft = lError;
+      if (lError->getWidth() != lValue->getWidth()) {
+        extendedLeft = ZExtExpr::create(lError, lValue->getWidth());
+      }
+      ref<Expr> extendedRight = rError;
+      if (rError->getWidth() != rValue->getWidth()) {
+        extendedRight = ZExtExpr::create(rError, rValue->getWidth());
+      }
+      ref<Expr> errorLeft = MulExpr::create(extendedLeft, lValue);
+      ref<Expr> errorRight = MulExpr::create(extendedRight, rValue);
+      ref<Expr> resultError = AddExpr::create(errorLeft, errorRight);
+
+      error = ExtractExpr::create(
+          error->isZero() ? error : UDivExpr::create(resultError, error), 0,
+          Expr::Int8);
+      i++;
+    }
+    if (kgepi->offset) {
+      ref<Expr> lError = error;
+      ref<Expr> lValue = base;
+      ref<Expr> rError = ConstantExpr::create(0, Expr::Int8);
+      ref<Expr> rValue = Expr::createPointer(kgepi->offset);
+
+      ref<Expr> extendedLeft = lError;
+      if (lError->getWidth() != lValue->getWidth()) {
+        extendedLeft = ZExtExpr::create(lError, lValue->getWidth());
+      }
+      ref<Expr> extendedRight = rError;
+      if (rError->getWidth() != rValue->getWidth()) {
+        extendedRight = ZExtExpr::create(rError, rValue->getWidth());
+      }
+      ref<Expr> errorLeft = MulExpr::create(extendedLeft, lValue);
+      ref<Expr> errorRight = MulExpr::create(extendedRight, rValue);
+      ref<Expr> resultError = AddExpr::create(errorLeft, errorRight);
+
+      error = ExtractExpr::create(
+          error->isZero() ? error : UDivExpr::create(resultError, error), 0,
+          Expr::Int8);
+    }
+
     if (error.isNull()) {
       error = ConstantExpr::create(0, Expr::Int8);
     }
-    return std::pair<ref<Expr>, ref<Expr> >(error, nullExpr);
+    return std::pair<ref<Expr>, ref<Expr> >(error, errorConstraint);
   }
   case llvm::Instruction::AShr:
   case llvm::Instruction::FPExt:

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -14,6 +14,7 @@
 #include "klee/Expr.h"
 #include "klee/util/ArrayCache.h"
 #include "klee/Internal/Module/Cell.h"
+#include "klee/Internal/Module/KInstruction.h"
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
 #include "llvm/IR/Instructions.h"
@@ -64,7 +65,7 @@ public:
                                      std::vector<ref<Expr> > &_inputErrorList);
 
   std::pair<ref<Expr>, ref<Expr> > propagateError(Executor *executor,
-                                                  llvm::Instruction *instr,
+                                                  KInstruction *ki,
                                                   ref<Expr> result,
                                                   std::vector<Cell> &arguments);
 

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -250,8 +250,8 @@ SymbolicError::~SymbolicError() {
   nonExited.clear();
 }
 
-void SymbolicError::executeStore(ref<Expr> address, ref<Expr> value,
-                                 ref<Expr> error) {
+void SymbolicError::executeStore(ref<Expr> address, ref<Expr> addressError,
+                                 ref<Expr> value, ref<Expr> error) {
     if (LoopBreaking && !writesStack.empty()) {
       // Record the error at each store at each iteration.
       if (llvm::isa<ConstantExpr>(address)) {
@@ -267,6 +267,13 @@ void SymbolicError::executeStore(ref<Expr> address, ref<Expr> value,
       } else {
         assert(!"non-constant address");
       }
+    }
+
+    if (!llvm::isa<ConstantExpr>(addressError)) {
+      // Here we constraint the error of the address to be 0, since it is not
+      // approximable.
+      constraintsWithError.push_back(
+          EqExpr::create(ConstantExpr::create(0, Expr::Int8), addressError));
     }
     storeError(address, error);
 }

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -221,7 +221,7 @@ ref<Expr> SymbolicError::propagateError(Executor *executor, KInstruction *ki,
                                         std::vector<Cell> &arguments,
                                         unsigned int phiResultWidth) {
   std::pair<ref<Expr>, ref<Expr> > error =
-      errorState->propagateError(executor, ki->inst, result, arguments);
+      errorState->propagateError(executor, ki, result, arguments);
 
   if (LoopBreaking) {
     if (TripCounter::instance &&

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -152,15 +152,7 @@ public:
 
   ref<Expr> executeLoad(llvm::Value *addressValue, ref<Expr> base,
                         ref<Expr> address, ref<Expr> addressError,
-                        ref<Expr> offset) {
-    if (!llvm::isa<ConstantExpr>(addressError)) {
-      // Here we constraint the error of the address to be 0, since it is not
-      // approximable.
-      constraintsWithError.push_back(
-          EqExpr::create(ConstantExpr::create(0, Expr::Int8), addressError));
-    }
-    return errorState->executeLoad(addressValue, base, address, offset);
-  }
+                        ref<Expr> offset);
 
   void setKleeBoundErrorExpr(ref<Expr> error) { kleeBoundErrorExpr = error; }
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -139,7 +139,8 @@ public:
 
   std::string &getOutputString() { return errorState->getOutputString(); }
 
-  void executeStore(ref<Expr> address, ref<Expr> value, ref<Expr> error);
+  void executeStore(ref<Expr> address, ref<Expr> addressError, ref<Expr> value,
+                    ref<Expr> error);
 
   void storeError(ref<Expr> address, ref<Expr> error) {
     errorState->executeStoreSimple(address, error);
@@ -150,7 +151,14 @@ public:
   }
 
   ref<Expr> executeLoad(llvm::Value *addressValue, ref<Expr> base,
-                        ref<Expr> address, ref<Expr> offset) {
+                        ref<Expr> address, ref<Expr> addressError,
+                        ref<Expr> offset) {
+    if (!llvm::isa<ConstantExpr>(addressError)) {
+      // Here we constraint the error of the address to be 0, since it is not
+      // approximable.
+      constraintsWithError.push_back(
+          EqExpr::create(ConstantExpr::create(0, Expr::Int8), addressError));
+    }
     return errorState->executeLoad(addressValue, base, address, offset);
   }
 


### PR DESCRIPTION
@Himeshi Made symbolic indices non-approximable by default by adding the constraint `0 = i` for any symbolic indices `i` used in `getelementptr`, `load`, and `store` in `.kquery_precision_error` file. Also added `-approximable-address` to prevent the generation of such constraints.

This feature can be tested on the `symbolic_index.c` example of fp-analysis/fp-examples#24. With this feature:
```
$ make symbolic_index.klee
...
$ cat symbolic_index.klee/test000001.kquery_precision_error 
Path conditions with error:(0 <= (i * (1 - error_i))) && ((i * (1 - error_i)) < 5) && (0 = error_i)
```
The last condition `(0 = error_i)` is added which constrains the symbolic index to be non-approximable.