### PR TITLE
Scale numerator to avoid divide by zero error

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -73,6 +73,8 @@ extern llvm::cl::opt<bool> DebugPrecision;
 
 extern llvm::cl::opt<bool> LoopBreaking;
 
+extern llvm::cl::opt<bool> ExecuteFloatAsInt;
+
 #ifdef ENABLE_METASMT
 
 enum MetaSMTBackendType

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -73,7 +73,7 @@ extern llvm::cl::opt<bool> DebugPrecision;
 
 extern llvm::cl::opt<bool> LoopBreaking;
 
-extern llvm::cl::opt<bool> ExecuteFloatAsInt;
+extern llvm::cl::opt<bool> Scaling;
 
 #ifdef ENABLE_METASMT
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -117,11 +117,11 @@ llvm::cl::opt<bool>
     UseAssignmentValidatingSolver("debug-assignment-validating-solver",
                                   llvm::cl::init(false));
 
-llvm::cl::opt<bool>
-ExecuteFloatAsInt("execute-float-as-int",
-                  llvm::cl::desc("Switch on numerical precision analysis "
-                                 "techniques used for floating point"),
-                  llvm::cl::init(false));
+llvm::cl::opt<bool> Scaling(
+    "scaling",
+    llvm::cl::desc(
+        "Scale numerator of divisions to prevent rounding the result to zero"),
+    llvm::cl::init(false));
 
 #ifdef ENABLE_METASMT
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -117,6 +117,12 @@ llvm::cl::opt<bool>
     UseAssignmentValidatingSolver("debug-assignment-validating-solver",
                                   llvm::cl::init(false));
 
+llvm::cl::opt<bool>
+ExecuteFloatAsInt("execute-float-as-int",
+                  llvm::cl::desc("Switch on numerical precision analysis "
+                                 "techniques used for floating point"),
+                  llvm::cl::init(false));
+
 #ifdef ENABLE_METASMT
 
 #ifdef METASMT_DEFAULT_BACKEND_IS_BTOR

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -751,3 +751,10 @@ void ErrorState::print(llvm::raw_ostream &os) const {
     }
   }
 }
+
+ref<Expr> ErrorState::getScalingConstraint() {
+  const Array *array = errorArrayCache.CreateArray("scaling", Expr::Int8);
+  ref<Expr> scalingVal = ReadExpr::create(
+      UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
+  return NeExpr::create(scalingVal, ConstantExpr::create(0, Expr::Int8));
+}

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -90,6 +90,9 @@ public:
   /// print - Print the object content to stream
   void print(llvm::raw_ostream &os) const;
 
+  // Add to constraint lists the constraint scalingVar != 0
+  ref<Expr> getScalingConstraint();
+
   /// dump - Print the object content to stderr
   void dump() const {
     print(llvm::errs());

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -9,6 +9,7 @@
 
 #include "SymbolicError.h"
 #include "klee/ExecutionState.h"
+#include "klee/CommandLine.h"
 
 #include "klee/Internal/Module/Cell.h"
 #include "klee/Internal/Module/InstructionInfoTable.h"
@@ -81,6 +82,10 @@ ExecutionState::ExecutionState(KFunction *kf) :
     ptreeNode(0),
 	symbolicError(new SymbolicError()) {
   pushFrame(0, kf);
+  if (PrecisionError && Scaling) {
+    ref<Expr> scalingConstraint = symbolicError->getSymbolicScalingConstraint();
+    addConstraint(scalingConstraint);
+  }
 }
 
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -83,7 +83,7 @@ ExecutionState::ExecutionState(KFunction *kf) :
 	symbolicError(new SymbolicError()) {
   pushFrame(0, kf);
   if (PrecisionError && Scaling) {
-    ref<Expr> scalingConstraint = symbolicError->getSymbolicScalingConstraint();
+    ref<Expr> scalingConstraint = symbolicError->getScalingConstraint();
     addConstraint(scalingConstraint);
   }
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2038,12 +2038,16 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     ref<Expr> left = lCell.value;
     ref<Expr> right = rCell.value;
-    ref<Expr> result;
+    ref<Expr> result = UDivExpr::create(left, right);
 
-    /* When float code is being executed as int, we want to avoid possible division by zero errors that occur when the numerator and denominator are both constatns and the numerator is smaller than the denominator (eg- 5/10 would be 0.5 in float but 0 in int). Therefore when the result of the division zero, scale the numerator by a non-zero value. If the numerator is already zero, then this should still result in the numerator being zero.*/
-    if (PrecisionError && ExecuteFloatAsInt) {
-      result = UDivExpr::create(left, right);
-
+    /* When float code is being executed as int, we want to avoid possible
+     * division by zero errors that occur when the numerator and denominator are
+     * both constatns and the numerator is smaller than the denominator (eg-
+     * 5/10 would be 0.5 in float but 0 in int). Therefore when the result of
+     * the division zero, scale the numerator by a non-zero value. If the
+     * numerator is already zero, then this should still result in the numerator
+     * being zero.*/
+    if (PrecisionError && Scaling) {
       if (ConstantExpr *cp = llvm::dyn_cast<ConstantExpr>(result)) {
         if (cp->getZExtValue() == 0) {
           const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
@@ -2055,8 +2059,6 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           result = UDivExpr::create(mulExpr, right);
         }
       }
-    } else {
-      result = UDivExpr::create(left, right);
     }
 
     std::vector<Cell> arguments;
@@ -2074,11 +2076,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     ref<Expr> left = lCell.value;
     ref<Expr> right = rCell.value;
-    ref<Expr> result;
+    ref<Expr> result = SDivExpr::create(left, right);
 
-    if (PrecisionError && ExecuteFloatAsInt) {
-      result = SDivExpr::create(left, right);
-
+    if (PrecisionError && Scaling) {
       if (ConstantExpr *cp = llvm::dyn_cast<ConstantExpr>(result)) {
         if (cp->getZExtValue() == 0) {
           const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
@@ -2090,8 +2090,6 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           result = SDivExpr::create(mulExpr, right);
         }
       }
-    } else {
-      result = SDivExpr::create(left, right);
     }
 
     std::vector<Cell> arguments;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2038,7 +2038,26 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     ref<Expr> left = lCell.value;
     ref<Expr> right = rCell.value;
-    ref<Expr> result = UDivExpr::create(left, right);
+    ref<Expr> result;
+
+    /* When float code is being executed as int, we want to avoid possible division by zero errors that occur when the numerator and denominator are both constatns and the numerator is smaller than the denominator (eg- 5/10 would be 0.5 in float but 0 in int). Therefore when the result of the division zero, scale the numerator by a non-zero value. If the numerator is already zero, then this should still result in the numerator being zero.*/
+    if (PrecisionError && ExecuteFloatAsInt) {
+      result = UDivExpr::create(left, right);
+
+      if (ConstantExpr *cp = llvm::dyn_cast<ConstantExpr>(result)) {
+        if (cp->getZExtValue() == 0) {
+          const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
+          ref<Expr> scalingVal =
+              ReadExpr::create(UpdateList(array, 0),
+                               ConstantExpr::create(0, array->getDomain()));
+          ref<Expr> mulExpr = MulExpr::create(
+              left, SExtExpr::create(scalingVal, left->getWidth()));
+          result = UDivExpr::create(mulExpr, right);
+        }
+      }
+    } else {
+      result = UDivExpr::create(left, right);
+    }
 
     std::vector<Cell> arguments;
     arguments.push_back(lCell);
@@ -2058,12 +2077,19 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     ref<Expr> result;
 
     if (PrecisionError && ExecuteFloatAsInt) {
-      const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
-      ref<Expr> scalingVal = ReadExpr::create(
-          UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
-      ref<Expr> mulExpr =
-          MulExpr::create(left, SExtExpr::create(scalingVal, left->getWidth()));
-      result = SDivExpr::create(mulExpr, right);
+      result = SDivExpr::create(left, right);
+
+      if (ConstantExpr *cp = llvm::dyn_cast<ConstantExpr>(result)) {
+        if (cp->getZExtValue() == 0) {
+          const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
+          ref<Expr> scalingVal =
+              ReadExpr::create(UpdateList(array, 0),
+                               ConstantExpr::create(0, array->getDomain()));
+          ref<Expr> mulExpr = MulExpr::create(
+              left, SExtExpr::create(scalingVal, left->getWidth()));
+          result = SDivExpr::create(mulExpr, right);
+        }
+      }
     } else {
       result = SDivExpr::create(left, right);
     }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2055,7 +2055,19 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     ref<Expr> left = lCell.value;
     ref<Expr> right = rCell.value;
-    ref<Expr> result = SDivExpr::create(left, right);
+    ref<Expr> result;
+
+    if (PrecisionError && ExecuteFloatAsInt) {
+      const Array *array = arrayCache.CreateArray("scaling", Expr::Int8);
+      ref<Expr> scalingVal = ReadExpr::create(
+          UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
+      ref<Expr> mulExpr =
+          MulExpr::create(left, SExtExpr::create(scalingVal, left->getWidth()));
+      right->dump();
+      result = SDivExpr::create(mulExpr, right);
+    } else {
+      result = SDivExpr::create(left, right);
+    }
 
     std::vector<Cell> arguments;
     arguments.push_back(lCell);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2063,7 +2063,6 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
           UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
       ref<Expr> mulExpr =
           MulExpr::create(left, SExtExpr::create(scalingVal, left->getWidth()));
-      right->dump();
       result = SDivExpr::create(mulExpr, right);
     } else {
       result = SDivExpr::create(left, right);

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -196,7 +196,7 @@ public:
     llvm::errs() << "\n";
   }
 
-  ref<Expr> getSymbolicScalingConstraint() {
+  ref<Expr> getScalingConstraint() {
     ref<Expr> scalingConstraint = errorState->getScalingConstraint();
     addErrorConstraint(scalingConstraint);
     return scalingConstraint;

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -195,6 +195,12 @@ public:
     print(llvm::errs());
     llvm::errs() << "\n";
   }
+
+  ref<Expr> getSymbolicScalingConstraint() {
+    ref<Expr> scalingConstraint = errorState->getScalingConstraint();
+    addErrorConstraint(scalingConstraint);
+    return scalingConstraint;
+  }
 };
 }
 


### PR DESCRIPTION
When executing floating point code by converting them an integer version, divide by zero errors can occur. To avoid this when the `--execute-float-as-int` scale the numerator by a symbolic value.