### PR TITLE
Added missing FCMP_UGT and FCMP_OGT cases

### DIFF
--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -432,6 +432,11 @@ ErrorState::propagateError(Executor *executor, llvm::Instruction *instr,
         conditionWithError = EqExpr::create(leftMul, rightMul);
         break;
       }
+      case llvm::FCmpInst::FCMP_UGT:
+      case llvm::FCmpInst::FCMP_OGT: {
+        conditionWithError = SgtExpr::create(leftMul, rightMul);
+        break;
+      }
       case llvm::FCmpInst::FCMP_UGE:
       case llvm::FCmpInst::FCMP_OGE: {
         conditionWithError = SgeExpr::create(leftMul, rightMul);


### PR DESCRIPTION
In `ErrorState::propagateError()`. This resolves the following crash:
```
klee -search=dfs -output-dir="$OUTPUT_DIR" $EXTRA_OPTIONS -precision foo1.bc
KLEE: output directory is "/home/dcsandr/software/fp-examples/basic/foo1.klee"
KLEE: Using STP solver backend
klee: ErrorState.cpp:464: std::pair<klee::ref<klee::Expr>, klee::ref<klee::Expr> > klee::ErrorState::propagateError(klee::Executor*, llvm::Instruction*, klee::ref<klee::Expr>, std::vector<klee::Cell>&): Assertion `!"Invalid FCMP predicate!"' failed.
0  libLLVM-3.4.so.1 0x00002b7415978042 llvm::sys::PrintStackTrace(_IO_FILE*) + 34
1  libLLVM-3.4.so.1 0x00002b7415977e34
2  libpthread.so.0  0x00002b741643f390
3  libc.so.6        0x00002b741899b428 gsignal + 56
4  libc.so.6        0x00002b741899d02a abort + 362
5  libc.so.6        0x00002b7418993bd7
6  libc.so.6        0x00002b7418993c82
7  klee             0x00000000004b8cf4 klee::ErrorState::propagateError(klee::Executor*, llvm::Instruction*, klee::ref<klee::Expr>, std::vector<klee::Cell, std::allocator<klee::Cell> >&) + 8260
8  klee             0x00000000004a81c4 klee::SymbolicError::propagateError(klee::Executor*, klee::KInstruction*, klee::ref<klee::Expr>, std::vector<klee::Cell, std::allocator<klee::Cell> >&, unsigned int) + 68
9  klee             0x00000000004751f9 klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) + 16041
10 klee             0x00000000004798bc klee::Executor::run(klee::ExecutionState&) + 1660
11 klee             0x000000000047a24f klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1791
12 klee             0x00000000004511ec main + 11916
13 libc.so.6        0x00002b7418986830 __libc_start_main + 240
14 klee             0x0000000000459059 _start + 41
Aborted (core dumped)
```