### PR TITLE
Added missing CMakeLists.txt entries

### DIFF
--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -11,6 +11,8 @@ klee_add_component(kleeCore
   CallPathManager.cpp
   Context.cpp
   CoreStats.cpp
+  EdgeProbability.cpp
+  ErrorState.cpp
   ExecutionState.cpp
   Executor.cpp
   ExecutorTimers.cpp
@@ -19,12 +21,15 @@ klee_add_component(kleeCore
   ImpliedValue.cpp
   Memory.cpp
   MemoryManager.cpp
+  PrettyExpressionBuilder.cpp
   PTree.cpp
   Searcher.cpp
   SeedInfo.cpp
   SpecialFunctionHandler.cpp
   StatsTracker.cpp
+  SymbolicError.cpp
   TimingSolver.cpp
+  TripCounter.cpp
   UserSearcher.cpp
 )
 

--- a/lib/Solver/CMakeLists.txt
+++ b/lib/Solver/CMakeLists.txt
@@ -28,6 +28,8 @@ klee_add_component(kleaverSolver
   ValidatingSolver.cpp
   Z3Builder.cpp
   Z3Solver.cpp
+  Z3ErrorBuilder.cpp
+  Z3ErrorSolver.cpp
 )
 
 set(LLVM_COMPONENTS


### PR DESCRIPTION
This patch is to fix linking failures when building using `cmake`, as instructed in the KLEE installation guilde, with error messages similar to the following:
```
[100%] Linking CXX executable ../../bin/klee
CMakeFiles/klee.dir/main.cpp.o: In function `KleeHandler::processTestCase(klee::ExecutionState const&, char const*, char const*)':
/home/andrew/software/fp-analysis-klee/tools/klee/main.cpp:520: undefined reference to `klee::PrettyExpressionBuilder::construct[abi:cxx11](klee::ref<klee::Expr>)'
/home/andrew/software/fp-analysis-klee/tools/klee/main.cpp:522: undefined reference to `klee::PrettyExpressionBuilder::construct[abi:cxx11](klee::ref<klee::Expr>)'
CMakeFiles/klee.dir/main.cpp.o: In function `llvm::Pass::Pass(llvm::PassKind, char&)':
/home/andrew/software/llvm-3.4.2/include/llvm/Pass.h:90: undefined reference to `klee::TripCounter::ID'
CMakeFiles/klee.dir/main.cpp.o: In function `klee::TripCounter::TripCounter()':
/home/andrew/software/fp-analysis-klee/tools/klee/../../include/klee/Internal/Module/TripCounter.h:63: undefined reference to `vtable for klee::TripCounter'
...
```