### PR TITLE
Added test for function nullity in Executor::executeInstruction()

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1837,7 +1837,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     Value *fp = cs.getCalledValue();
     Function *f = getTargetFunction(fp, state);
 
-    if (f->getName().str() == "klee_bound_error") {
+    if (f && f->getName().str() == "klee_bound_error") {
       ref<Expr> error = eval(ki, 1, state).error;
       state.symbolicError->setKleeBoundErrorExpr(error);
     }


### PR DESCRIPTION
To prevent segfaults such as the following:
```
0  klee            0x0000000000f5c042 llvm::sys::PrintStackTrace(_IO_FILE*) + 50
1  klee            0x0000000000f5b894
2  libpthread.so.0 0x00002abffec14390
3  klee            0x0000000000f0b160 llvm::Value::getName() const + 0
4  klee            0x0000000000572e97 klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) + 7415
5  klee            0x0000000000578d98 klee::Executor::run(klee::ExecutionState&) + 1768
6  klee            0x000000000057960a klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1818
7  klee            0x0000000000547850 main + 11280
8  libc.so.6       0x00002abfff8e5830 __libc_start_main + 240
9  klee            0x000000000055a929 _start + 41
Makefile:23: recipe for target 'memdjpeg.klee' failed
make: *** [memdjpeg.klee] Segmentation fault (core dumped)
```