### PR TITLE
Fix to crash due to deallocated Array object

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -153,7 +153,7 @@ private:
   ExecutionState() : ptreeNode(0), symbolicError(0) {}
 
 public:
-  ExecutionState(KFunction *kf);
+  ExecutionState(KFunction *kf, ArrayCache *arrayCache);
 
   // XXX total hack, just used to make a state so solver can
   // use on structure

--- a/include/klee/util/PrettyExpressionBuilder.h
+++ b/include/klee/util/PrettyExpressionBuilder.h
@@ -116,9 +116,6 @@ class PrettyExpressionBuilder {
 
 public:
   static std::string construct(ref<Expr> e);
-
-  static std::string constructQuery(ConstraintManager &constraints,
-                                    ref<Expr> e);
 };
 
 /// \brief Output function name to the output stream

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -44,7 +44,7 @@ ref<Expr> ErrorState::getError(Executor *executor, ref<Expr> valueExpr,
           "_unspecified_error_" +
           llvm::dyn_cast<ReadExpr>(concatExpr->getLeft())->updates.root->name);
       const Array *newErrorArray =
-          errorArrayCache.CreateArray(errorName, Expr::Int8);
+          errorArrayCache->CreateArray(errorName, Expr::Int8);
       UpdateList ul(newErrorArray, 0);
       arrayErrorArrayMap[concatArray] = newErrorArray;
       ret = ReadExpr::create(ul, ConstantExpr::alloc(0, Expr::Int8));
@@ -60,7 +60,7 @@ ref<Expr> ErrorState::getError(Executor *executor, ref<Expr> valueExpr,
       std::string errorName("_unspecified_error_" +
                             readExpr->updates.root->name);
       const Array *newErrorArray =
-          errorArrayCache.CreateArray(errorName, Expr::Int8);
+          errorArrayCache->CreateArray(errorName, Expr::Int8);
       UpdateList ul(newErrorArray, 0);
       arrayErrorArrayMap[readArray] = newErrorArray;
       ret = ReadExpr::create(ul, ConstantExpr::alloc(0, Expr::Int8));
@@ -126,7 +126,7 @@ ErrorState::outputErrorBound(llvm::Instruction *inst, ref<Expr> error,
   errorVarStream.flush();
 
   ref<Expr> errorVarExpr = ReadExpr::create(
-      UpdateList(errorArrayCache.CreateArray(errorVar, Expr::Int8), 0),
+      UpdateList(errorArrayCache->CreateArray(errorVar, Expr::Int8), 0),
       ConstantExpr::createPointer(0));
 
   ret.addConstraint(EqExpr::create(errorVarExpr, error));
@@ -657,7 +657,7 @@ ref<Expr> ErrorState::executeLoad(llvm::Value *addressValue, ref<Expr> base,
           offset = Expr::createPointer(0);
         }
         const Array *newErrorArray =
-            errorArrayCache.CreateArray(errorName, Expr::Int8);
+            errorArrayCache->CreateArray(errorName, Expr::Int8);
         UpdateList ul(newErrorArray, 0);
         error = ReadExpr::create(ul, offset);
       } else if (!errorName.compare(0, array_prefix16.size(), array_prefix16)) {
@@ -674,7 +674,7 @@ ref<Expr> ErrorState::executeLoad(llvm::Value *addressValue, ref<Expr> base,
           offset = Expr::createPointer(0);
         }
         const Array *newErrorArray =
-            errorArrayCache.CreateArray(errorName, Expr::Int8);
+            errorArrayCache->CreateArray(errorName, Expr::Int8);
         UpdateList ul(newErrorArray, 0);
         error = ReadExpr::create(ul, offset);
       } else if (!errorName.compare(0, array_prefix32.size(), array_prefix32)) {
@@ -691,7 +691,7 @@ ref<Expr> ErrorState::executeLoad(llvm::Value *addressValue, ref<Expr> base,
           offset = Expr::createPointer(0);
         }
         const Array *newErrorArray =
-            errorArrayCache.CreateArray(errorName, Expr::Int8);
+            errorArrayCache->CreateArray(errorName, Expr::Int8);
         UpdateList ul(newErrorArray, 0);
         error = ReadExpr::create(ul, offset);
       } else if (!errorName.compare(0, array_prefix64.size(), array_prefix64)) {
@@ -708,7 +708,7 @@ ref<Expr> ErrorState::executeLoad(llvm::Value *addressValue, ref<Expr> base,
           offset = Expr::createPointer(0);
         }
         const Array *newErrorArray =
-            errorArrayCache.CreateArray(errorName, Expr::Int8);
+            errorArrayCache->CreateArray(errorName, Expr::Int8);
         UpdateList ul(newErrorArray, 0);
         error = ReadExpr::create(ul, offset);
       } else {
@@ -758,7 +758,7 @@ void ErrorState::print(llvm::raw_ostream &os) const {
 }
 
 ref<Expr> ErrorState::getScalingConstraint() {
-  const Array *array = errorArrayCache.CreateArray("scaling", Expr::Int8);
+  const Array *array = errorArrayCache->CreateArray("scaling", Expr::Int8);
   ref<Expr> scalingVal = ReadExpr::create(
       UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
   return NeExpr::create(scalingVal, ConstantExpr::create(0, Expr::Int8));

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -34,7 +34,7 @@ private:
   ref<Expr> getError(Executor *executor, ref<Expr> valueExpr,
                      llvm::Value *value = 0);
 
-  ArrayCache errorArrayCache;
+  ArrayCache *errorArrayCache;
 
   std::string outputString;
 
@@ -45,9 +45,11 @@ private:
   std::vector<ref<Expr> > inputErrorList;
 
 public:
-  ErrorState() : refCount(0) {}
+  ErrorState(ArrayCache *arrayCache)
+      : refCount(0), errorArrayCache(arrayCache) {}
 
-  ErrorState(ErrorState &errorState) : refCount(0) {
+  ErrorState(ErrorState &errorState)
+      : refCount(0), errorArrayCache(errorState.errorArrayCache) {
     declaredInputError = errorState.declaredInputError;
     storedError = errorState.storedError;
     inputErrorList = errorState.inputErrorList;

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -68,19 +68,10 @@ StackFrame::~StackFrame() {
 
 /***/
 
-ExecutionState::ExecutionState(KFunction *kf) :
-    pc(kf->instructions),
-    prevPC(pc),
-
-    queryCost(0.), 
-    weight(1),
-    depth(0),
-
-    instsSinceCovNew(0),
-    coveredNew(false),
-    forkDisabled(false),
-    ptreeNode(0),
-	symbolicError(new SymbolicError()) {
+ExecutionState::ExecutionState(KFunction *kf, ArrayCache *arrayCache)
+    : pc(kf->instructions), prevPC(pc), queryCost(0.), weight(1), depth(0),
+      instsSinceCovNew(0), coveredNew(false), forkDisabled(false), ptreeNode(0),
+      symbolicError(new SymbolicError(arrayCache)) {
   pushFrame(0, kf);
   if (PrecisionError && Scaling) {
     ref<Expr> scalingConstraint = symbolicError->getScalingConstraint();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4469,8 +4469,9 @@ void Executor::runFunctionAsMain(Function *f,
     }
   }
 
-  ExecutionState *state = new ExecutionState(kmodule->functionMap[f]);
-  
+  ExecutionState *state =
+      new ExecutionState(kmodule->functionMap[f], &arrayCache);
+
   if (pathWriter) 
     state->pathOS = pathWriter->open();
   if (symPathWriter) 

--- a/lib/Core/PrettyExpressionBuilder.cpp
+++ b/lib/Core/PrettyExpressionBuilder.cpp
@@ -667,29 +667,12 @@ std::string PrettyExpressionBuilder::constructActual(ref<Expr> e) {
     return getTrue();
   }
 }
+
 std::string PrettyExpressionBuilder::construct(ref<Expr> e) {
   PrettyExpressionBuilder *instance = new PrettyExpressionBuilder();
   std::string ret = instance->constructActual(e);
   delete instance;
   return ret;
-}
-
-std::string
-PrettyExpressionBuilder::constructQuery(ConstraintManager &constraints,
-                                        ref<Expr> query) {
-  std::string msg;
-  std::string tabs = makeTabs(1);
-  llvm::raw_string_ostream stream(msg);
-  stream << "antecedent:\n";
-  for (ConstraintManager::const_iterator it = constraints.begin(),
-                                         ie = constraints.end();
-       it != ie; ++it) {
-    stream << tabs << construct(*it) << "\n";
-  }
-  stream << "consequent:\n";
-  stream << tabs << construct(query) << "\n";
-  stream.flush();
-  return msg;
 }
 
 std::string PrettyExpressionBuilder::buildArray(const char *name,

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -71,8 +71,9 @@ class SymbolicError {
   int branchCount;
 
 public:
-  SymbolicError() : pathProbability(-1.0), branchCount(0) {
-    errorState = ref<ErrorState>(new ErrorState());
+  SymbolicError(ArrayCache *arrayCache)
+      : pathProbability(-1.0), branchCount(0) {
+    errorState = ref<ErrorState>(new ErrorState(arrayCache));
   }
 
   SymbolicError(SymbolicError &symErr)


### PR DESCRIPTION
This fix assigns `Executor::arrayCache`, which is more permanent, to `ErrorState::errorArrayCache` to prevent crashes such as the following:
```
0  klee            0x0000000000f5bfe2 llvm::sys::PrintStackTrace(_IO_FILE*) + 50
1  klee            0x0000000000f5b834
2  libpthread.so.0 0x00002ae1dd900390
3  libc.so.6       0x00002ae1de63c746 strlen + 38
4  klee            0x0000000000590ffb klee::PrettyExpressionBuilder::getInitialArray[abi:cxx11](klee::Array const*) + 75
5  klee            0x0000000000591495 klee::PrettyExpressionBuilder::getArrayForUpdate[abi:cxx11](klee::Array const*, klee::UpdateNode const*) + 341
6  klee            0x000000000059052a klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 5258
7  klee            0x0000000000590093 klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 4083
8  klee            0x000000000059065f klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 5567
9  klee            0x000000000058ff82 klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 3810
10 klee            0x000000000058f403 klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 867
11 klee            0x000000000058f403 klee::PrettyExpressionBuilder::constructActual[abi:cxx11](klee::ref<klee::Expr>) + 867
12 klee            0x00000000005914ea klee::PrettyExpressionBuilder::construct[abi:cxx11](klee::ref<klee::Expr>) + 74
13 klee            0x000000000055dcf7
14 klee            0x0000000000567a56 klee::Executor::terminateStateOnExit(klee::ExecutionState&) + 38
15 klee            0x0000000000596fe7 klee::SpecialFunctionHandler::handle(klee::ExecutionState&, llvm::Function*, klee::KInstruction*, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&) + 199
16 klee            0x0000000000568077 klee::Executor::callExternalFunction(klee::ExecutionState&, klee::KInstruction*, llvm::Function*, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&) + 87
17 klee            0x0000000000570caa klee::Executor::executeCall(klee::ExecutionState&, klee::KInstruction*, llvm::Function*, std::vector<klee::Cell, std::allocator<klee::Cell> >&) + 2266
18 klee            0x0000000000573575 klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) + 9173
19 klee            0x0000000000578d38 klee::Executor::run(klee::ExecutionState&) + 1768
20 klee            0x00000000005795aa klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1818
21 klee            0x0000000000547850 main + 11280
22 libc.so.6       0x00002ae1de5d1830 __libc_start_main + 240
23 klee            0x000000000055a929 _start + 41
Makefile:44: recipe for target 'memdjpeg.klee' failed
make: *** [memdjpeg.klee] Segmentation fault (core dumped)
```
The crash was because ErrorState::errorArrayCache was cleared (deallocated) too soon when it is still needed by PrettyExpressionBuilder. By substituting the original ErrorState::errorArrayCache with Executor::arrayCache, the array cache is still available when it is used by PrettyExpressionBuilder.