### PR TITLE
[WIP] Real arithmetc domain solving for solving constraints with error

### DIFF
--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -246,7 +246,7 @@ namespace klee {
   class Z3ErrorSolver : public Solver {
   public:
     /// Z3Solver - Construct a new Z3Solver.
-    Z3ErrorSolver();
+    Z3ErrorSolver(bool real);
 
     /// Get the query in SMT-LIBv2 format.
     /// \return A C-style string. The caller is responsible for freeing this.

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -261,7 +261,8 @@ namespace klee {
                               const std::vector<const Array *> &objects,
                               std::vector<bool> &infinity,
                               std::vector<std::pair<int, double> > &values,
-                              std::vector<bool> &epsilon, bool &hasSolution);
+                              std::vector<bool> &epsilon, bool &hasSolution,
+                              bool maximize);
   };
 #endif // ENABLE_Z3
 

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -259,10 +259,8 @@ namespace klee {
     /// computeOptimalValues - Compute optimal values of objects
     bool computeOptimalValues(const Query &query,
                               const std::vector<const Array *> &objects,
-                              std::vector<bool> &infinity,
                               std::vector<std::pair<int, double> > &values,
-                              std::vector<bool> &epsilon, bool &hasSolution,
-                              bool maximize);
+                              bool &hasSolution, bool maximize);
   };
 #endif // ENABLE_Z3
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -476,7 +476,8 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
       bool hasSolution;
       Query queryWithFalse(cm, ConstantExpr::create(0, Expr::Bool));
       bool success = executor.errorSolver->computeOptimalValues(
-          queryWithFalse, objects, infinity, values, epsilon, hasSolution);
+          queryWithFalse, objects, infinity, values, epsilon, hasSolution,
+          true);
 
       assert(success && hasSolution && "state has invalid constraint set");
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -470,14 +470,11 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
         cm.addConstraint(*it);
       }
 
-      std::vector<bool> infinity;
       std::vector<std::pair<int, double> > values;
-      std::vector<bool> epsilon;
       bool hasSolution;
       Query queryWithFalse(cm, ConstantExpr::create(0, Expr::Bool));
       bool success = executor.errorSolver->computeOptimalValues(
-          queryWithFalse, objects, infinity, values, epsilon, hasSolution,
-          true);
+          queryWithFalse, objects, values, hasSolution, true);
 
       assert(success && hasSolution && "state has invalid constraint set");
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -62,7 +62,7 @@ class SymbolicError {
   ref<Expr> kleeBoundErrorExpr;
 
   /// \brief Contains the path conditions with propagated error
-  std::vector<ref<Expr> > constraintsWithError;
+  ConstraintManager constraintsWithError;
 
   /// \brief The path probability
   double pathProbability;
@@ -174,12 +174,10 @@ public:
 
   double getBranchCount() const { return branchCount; }
 
-  std::vector<ref<Expr> > &getConstraintsWithError() {
-    return constraintsWithError;
-  }
+  ConstraintManager &getConstraintsWithError() { return constraintsWithError; }
 
   void addErrorConstraint(ref<Expr> error) {
-    constraintsWithError.push_back(error);
+    constraintsWithError.addConstraint(error);
   }
 
   /// print - Print the object content to stream

--- a/lib/Solver/CoreSolver.cpp
+++ b/lib/Solver/CoreSolver.cpp
@@ -102,7 +102,9 @@ Solver *createCoreSolver(CoreSolverType cst) {
 Z3ErrorSolver *createCoreErrorSolver() {
   if (ComputeErrorBound != NO_COMPUTATION) {
     klee_message("Using Z3 for reasoning about error expressions");
-    return new Z3ErrorSolver();
+    if (ComputeErrorBound == VIA_REAL)
+      return new Z3ErrorSolver(true);
+    return new Z3ErrorSolver(false);
   }
   return NULL;
 }

--- a/lib/Solver/Z3ErrorBuilder.cpp
+++ b/lib/Solver/Z3ErrorBuilder.cpp
@@ -56,8 +56,10 @@ void Z3ErrorArrayExprHash::clear() {
   _array_hash.clear();
 }
 
-Z3ErrorBuilder::Z3ErrorBuilder(bool autoClearConstructCache)
+Z3ErrorBuilder::Z3ErrorBuilder(bool _real, bool autoClearConstructCache)
     : autoClearConstructCache(autoClearConstructCache) {
+  real = _real;
+
   // FIXME: Should probably let the client pass in a Z3_config instead
   Z3_config cfg = Z3_mk_config();
   // It is very important that we ask Z3 to let us manage memory so that

--- a/lib/Solver/Z3ErrorBuilder.h
+++ b/lib/Solver/Z3ErrorBuilder.h
@@ -162,11 +162,12 @@ private:
   Z3SortHandle getIntSort();
   Z3SortHandle getArraySort(Z3SortHandle domainSort, Z3SortHandle rangeSort);
   bool autoClearConstructCache;
+  bool real;
 
 public:
   Z3_context ctx;
 
-  Z3ErrorBuilder(bool autoClearConstructCache = true);
+  Z3ErrorBuilder(bool _real, bool autoClearConstructCache = true);
   ~Z3ErrorBuilder();
 
   Z3ErrorASTHandle getTrue();

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -509,11 +509,10 @@ void KleeHandler::processTestCase(const ExecutionState &state,
 
     if (PrecisionError) {
       llvm::raw_ostream *f = openTestFile("kquery_precision_error", id);
-      std::vector<ref<Expr> > &constraintsWithError =
+      ConstraintManager &constraintsWithError =
           state.symbolicError->getConstraintsWithError();
-      for (std::vector<ref<Expr> >::const_iterator
-               it = constraintsWithError.begin(),
-               ie = constraintsWithError.end();
+      for (ConstraintManager::const_iterator it = constraintsWithError.begin(),
+                                             ie = constraintsWithError.end();
            it != ie; ++it) {
         if (it != constraintsWithError.begin())
           *f << " && " << PrettyExpressionBuilder::construct(*it);
@@ -521,9 +520,8 @@ void KleeHandler::processTestCase(const ExecutionState &state,
           *f << PrettyExpressionBuilder::construct(*it);
       }
       *f << "\n";
-      for (std::vector<ref<Expr> >::const_iterator
-               it = state.constraints.begin(),
-               ie = state.constraints.end();
+      for (ConstraintManager::const_iterator it = state.constraints.begin(),
+                                             ie = state.constraints.end();
            it != ie; ++it) {
         if (it != state.constraints.begin())
           *f << " && " << PrettyExpressionBuilder::construct(*it);


### PR DESCRIPTION
**This is not ready to be merged.** This implementation is to compute input values, given path condition (with error), using Z3 real number domain solver.

As a note, the next thing to do would be to implement a new Z3 interface for this. Current Z3ErrorSolver::computeOptimalValue() is for computing optimal value (bounds), whereas Z3ErrorSolve::computeInitialValue() is limited to bitvector values only (we only need real number result instead).