### PR TITLE
Generate multiple ktest files for a path condition

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -75,6 +75,8 @@ extern llvm::cl::opt<bool> LoopBreaking;
 
 extern llvm::cl::opt<bool> Scaling;
 
+extern llvm::cl::opt<int> MultiKTest;
+
 #ifdef ENABLE_METASMT
 
 enum MetaSMTBackendType

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -9,6 +9,8 @@
 #ifndef KLEE_INTERPRETER_H
 #define KLEE_INTERPRETER_H
 
+#include <klee/Expr.h>
+
 #include <vector>
 #include <string>
 #include <map>
@@ -149,11 +151,15 @@ public:
                                 std::string &res,
                                 LogType logFormat = STP) = 0;
 
-  virtual bool getSymbolicSolution(const ExecutionState &state, 
-                                   std::vector< 
-                                   std::pair<std::string,
-                                   std::vector<unsigned char> > >
-                                   &res) = 0;
+  virtual bool getSymbolicSolution(
+      const ExecutionState &state,
+      std::vector<std::pair<std::string, std::vector<unsigned char> > > &res,
+      std::vector<ref<Expr> > &equalities) = 0;
+
+  virtual bool getMultipleSymbolicSolutions(
+      unsigned max, const ExecutionState &state,
+      std::vector<std::vector<
+          std::pair<std::string, std::vector<unsigned char> > > > &res) = 0;
 
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res) = 0;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -123,6 +123,11 @@ llvm::cl::opt<bool> Scaling(
         "Scale numerator of divisions to prevent rounding the result to zero"),
     llvm::cl::init(false));
 
+llvm::cl::opt<int>
+MultiKTest("multi-ktest", llvm::cl::init(0), llvm::cl::value_desc("number"),
+           llvm::cl::desc("Try to produce a specified number of ktest files of "
+                          "different solutions"));
+
 #ifdef ENABLE_METASMT
 
 #ifdef METASMT_DEFAULT_BACKEND_IS_BTOR

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -512,11 +512,15 @@ public:
                                 std::string &res,
                                 Interpreter::LogType logFormat = Interpreter::STP);
 
-  virtual bool getSymbolicSolution(const ExecutionState &state, 
-                                   std::vector< 
-                                   std::pair<std::string,
-                                   std::vector<unsigned char> > >
-                                   &res);
+  virtual bool getSymbolicSolution(
+      const ExecutionState &state,
+      std::vector<std::pair<std::string, std::vector<unsigned char> > > &res,
+      std::vector<ref<Expr> > &equalities);
+
+  virtual bool getMultipleSymbolicSolutions(
+      unsigned max, const ExecutionState &state,
+      std::vector<std::vector<
+          std::pair<std::string, std::vector<unsigned char> > > > &res);
 
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res);


### PR DESCRIPTION
@Himeshi This resolves #73 . This should work with either Z3 or STP as backend solver. The option added is `-multi-ktest=<N>` where `<N>` is the maximum number of `.ktest` files `test<M>.ktest1` ... `test<M>.ktest<N>` for each test. It is possible that the number of `.ktest` files is less than `N` since it may not be impossible for the path condition to have as many as `N` solutions.