### PR TITLE
Path condition real solutions

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -67,6 +67,8 @@ enum ErrorBoundComputationDomain {
 
 extern llvm::cl::opt<ErrorBoundComputationDomain> ComputeErrorBound;
 
+extern llvm::cl::opt<bool> ComputeRealSolution;
+
 extern llvm::cl::opt<bool> UniformInputError;
 
 extern llvm::cl::opt<bool> DebugPrecision;

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -156,6 +156,10 @@ public:
       std::vector<std::pair<std::string, std::vector<unsigned char> > > &res,
       std::vector<ref<Expr> > &equalities) = 0;
 
+  virtual bool getRealSymbolicSolution(
+      const ExecutionState &state,
+      std::vector<std::pair<std::string, double> > &res) = 0;
+
   virtual bool getMultipleSymbolicSolutions(
       unsigned max, const ExecutionState &state,
       std::vector<std::vector<

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -101,6 +101,11 @@ llvm::cl::opt<ErrorBoundComputationDomain> ComputeErrorBound(
                      clEnumValEnd),
     llvm::cl::init(NO_COMPUTATION));
 
+llvm::cl::opt<bool> ComputeRealSolution(
+    "compute-real-solution",
+    llvm::cl::desc("Output real number solution in .reals file"),
+    llvm::cl::init(false));
+
 llvm::cl::opt<bool> UniformInputError(
     "uniform-input-error",
     llvm::cl::desc(

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -517,6 +517,10 @@ public:
       std::vector<std::pair<std::string, std::vector<unsigned char> > > &res,
       std::vector<ref<Expr> > &equalities);
 
+  virtual bool
+  getRealSymbolicSolution(const ExecutionState &state,
+                          std::vector<std::pair<std::string, double> > &res);
+
   virtual bool getMultipleSymbolicSolutions(
       unsigned max, const ExecutionState &state,
       std::vector<std::vector<

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -478,7 +478,8 @@ SpecialFunctionHandler::handleBoundError(ExecutionState &state,
       bool success = executor.errorSolver->computeOptimalValues(
           queryWithFalse, objects, infinity, values, epsilon, hasSolution);
 
-      assert(success && hasSolution && "state has invalid constraint set");
+      if (!(success && hasSolution))
+        assert(!"state has invalid constraint set");
 
       if (DebugPrecision) {
         for (unsigned i = 0; i < inputErrorList.size(); ++i) {

--- a/lib/Solver/CoreSolver.cpp
+++ b/lib/Solver/CoreSolver.cpp
@@ -100,8 +100,9 @@ Solver *createCoreSolver(CoreSolverType cst) {
 
 #ifdef ENABLE_Z3
 Z3ErrorSolver *createCoreErrorSolver() {
-  if (ComputeErrorBound != NO_COMPUTATION) {
-    klee_message("Using Z3 for reasoning about error expressions");
+  if (ComputeErrorBound != NO_COMPUTATION || ComputeRealSolution) {
+    klee_message(
+        "Using Z3 for reasoning about error expressions and/or path condition");
     return new Z3ErrorSolver();
   }
   return NULL;

--- a/lib/Solver/Z3ErrorBuilder.cpp
+++ b/lib/Solver/Z3ErrorBuilder.cpp
@@ -56,8 +56,10 @@ void Z3ErrorArrayExprHash::clear() {
   _array_hash.clear();
 }
 
-Z3ErrorBuilder::Z3ErrorBuilder(bool autoClearConstructCache)
-    : autoClearConstructCache(autoClearConstructCache) {
+Z3ErrorBuilder::Z3ErrorBuilder(bool _viaIntegerSolving,
+                               bool autoClearConstructCache)
+    : viaIntegerSolving(_viaIntegerSolving),
+      autoClearConstructCache(autoClearConstructCache) {
   // FIXME: Should probably let the client pass in a Z3_config instead
   Z3_config cfg = Z3_mk_config();
   // It is very important that we ask Z3 to let us manage memory so that
@@ -97,7 +99,7 @@ Z3SortHandle Z3ErrorBuilder::getArraySort(Z3SortHandle domainSort,
 Z3ErrorASTHandle Z3ErrorBuilder::buildArray(const char *name) {
   Z3SortHandle domainSort = getIntSort();
   Z3SortHandle rangeSort;
-  if (ComputeErrorBound == VIA_INTEGER) {
+  if (viaIntegerSolving) {
     rangeSort = getIntSort();
   } else {
     rangeSort = getRealSort();
@@ -387,7 +389,7 @@ Z3ErrorASTHandle Z3ErrorBuilder::constructActual(ref<Expr> e) {
         name.erase(0, 9);
         name += "__index__" + so.str();
       }
-      if (ComputeErrorBound == VIA_INTEGER) {
+      if (viaIntegerSolving) {
         return buildInteger(name.c_str());
       }
       return buildReal(name.c_str());

--- a/lib/Solver/Z3ErrorBuilder.h
+++ b/lib/Solver/Z3ErrorBuilder.h
@@ -161,12 +161,13 @@ private:
   Z3SortHandle getRealSort();
   Z3SortHandle getIntSort();
   Z3SortHandle getArraySort(Z3SortHandle domainSort, Z3SortHandle rangeSort);
+  bool viaIntegerSolving;
   bool autoClearConstructCache;
 
 public:
   Z3_context ctx;
 
-  Z3ErrorBuilder(bool autoClearConstructCache = true);
+  Z3ErrorBuilder(bool _viaIntegerSolving, bool autoClearConstructCache = true);
   ~Z3ErrorBuilder();
 
   Z3ErrorASTHandle getTrue();

--- a/lib/Solver/Z3ErrorSolver.cpp
+++ b/lib/Solver/Z3ErrorSolver.cpp
@@ -374,7 +374,10 @@ SolverImpl::SolverRunStatus Z3ErrorSolverImpl::handleSolverResponse(
       bool successfulEval =
           Z3_model_eval(builder->ctx, theModel, initial_read,
                         /*model_completion=*/Z3_TRUE, &arrayElementExpr);
-      assert(successfulEval && "Failed to evaluate model");
+      if (!successfulEval) {
+        assert(!"Failed to evaluate model");
+      }
+
       Z3_inc_ref(builder->ctx, arrayElementExpr);
       assert(Z3_get_ast_kind(builder->ctx, arrayElementExpr) ==
                  Z3_NUMERAL_AST &&
@@ -397,8 +400,9 @@ SolverImpl::SolverRunStatus Z3ErrorSolverImpl::handleSolverResponse(
             builder->ctx, Z3_get_denominator(builder->ctx, arrayElementExpr),
             &denominator);
 
-        assert(successNumerator && successDenominator &&
-               "failed to get value back");
+        if (!(successNumerator && successDenominator))
+          assert(!"failed to get value back");
+
         double result = ((double)numerator) / ((double)denominator);
 
         uint64_t intResult = 0;
@@ -512,8 +516,9 @@ SolverImpl::SolverRunStatus Z3ErrorSolverImpl::handleOptimizeResponse(
             builder->ctx, Z3_get_denominator(builder->ctx, upperBound),
             &denominator);
 
-        assert(successNumerator && successDenominator &&
-               "failed to get value back");
+        if (!(successNumerator && successDenominator))
+          assert(!"failed to get value back");
+
         result = ((double)numerator) / ((double)denominator);
       }
       Z3_dec_ref(builder->ctx, upperBound);

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -253,7 +253,10 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
         bool successfulEval =
             Z3_model_eval(builder->ctx, theModel, initial_read,
                           /*model_completion=*/Z3_TRUE, &arrayElementExpr);
-        assert(successfulEval && "Failed to evaluate model");
+
+        if (!successfulEval)
+          assert(!"Failed to evaluate model");
+
         Z3_inc_ref(builder->ctx, arrayElementExpr);
         assert(Z3_get_ast_kind(builder->ctx, arrayElementExpr) ==
                    Z3_NUMERAL_AST &&
@@ -262,7 +265,10 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
         int arrayElementValue = 0;
         bool successGet = Z3_get_numeral_int(builder->ctx, arrayElementExpr,
                                              &arrayElementValue);
-        assert(successGet && "failed to get value back");
+
+        if (!successGet)
+          assert(!"failed to get value back");
+
         assert(arrayElementValue >= 0 && arrayElementValue <= 255 &&
                "Integer from model is out of range");
         data.push_back(arrayElementValue);

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -608,6 +608,21 @@ void KleeHandler::processTestCase(const ExecutionState &state,
          << elapsed_time << "s\n";
       delete f;
     }
+
+    // Output the real number solution
+    std::vector<std::pair<std::string, double> > realSolutions;
+    success = m_interpreter->getRealSymbolicSolution(state, realSolutions);
+
+    if (success && realSolutions.size() > 0) {
+      llvm::raw_ostream *f = openTestFile("reals", id);
+      for (std::vector<std::pair<std::string, double> >::iterator
+               it = realSolutions.begin(),
+               ie = realSolutions.end();
+           it != ie; ++it) {
+        *f << it->first << " : " << it->second << "\n";
+      }
+      delete f;
+    }
   }
 }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -609,19 +609,21 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       delete f;
     }
 
-    // Output the real number solution
-    std::vector<std::pair<std::string, double> > realSolutions;
-    success = m_interpreter->getRealSymbolicSolution(state, realSolutions);
+    if (ComputeRealSolution) {
+      // Output the real number solution
+      std::vector<std::pair<std::string, double> > realSolutions;
+      success = m_interpreter->getRealSymbolicSolution(state, realSolutions);
 
-    if (success && realSolutions.size() > 0) {
-      llvm::raw_ostream *f = openTestFile("reals", id);
-      for (std::vector<std::pair<std::string, double> >::iterator
-               it = realSolutions.begin(),
-               ie = realSolutions.end();
-           it != ie; ++it) {
-        *f << it->first << " : " << it->second << "\n";
+      if (success && realSolutions.size() > 0) {
+        llvm::raw_ostream *f = openTestFile("reals", id);
+        for (std::vector<std::pair<std::string, double> >::iterator
+                 it = realSolutions.begin(),
+                 ie = realSolutions.end();
+             it != ie; ++it) {
+          *f << it->first << " : " << it->second << "\n";
+        }
+        delete f;
       }
-      delete f;
     }
   }
 }


### PR DESCRIPTION
This adds an option `-compute-real-solution` to get real number solutions for the input values in `test<N>.reals` files from the path condition constraints. It seems for at least the simple test examples, the solution obtained equals the integral solution. It cannot be ascertained if this will always be the case.
