### PR TITLE
Limit checking of validity to the case when no -no-branch-check

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1026,7 +1026,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
 
 void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(condition)) {
-    if (!CE->isTrue())
+    if (!NoBranchCheck && !CE->isTrue())
       llvm::report_fatal_error("attempt to add invalid constraint");
     return;
   }


### PR DESCRIPTION
In `Executor::addConstraint`, when it is not specified.