### PR TITLE
Handle math calls

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -77,6 +77,8 @@ extern llvm::cl::opt<bool> LoopBreaking;
 
 extern llvm::cl::opt<bool> Scaling;
 
+extern llvm::cl::opt<bool> MathCalls;
+
 extern llvm::cl::opt<int> MultiKTest;
 
 extern llvm::cl::opt<bool> NoBranchCheck;

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -178,8 +178,6 @@ public:
   void dumpStack(llvm::raw_ostream &out) const;
 
   std::string getNewMathVarName(std::string mathFunctionName);
-  ref<Expr> getNewSymbolicMathErrorVariable(ref<Expr> mathVar,
-                                            std::string mathVarName);
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -145,9 +145,6 @@ public:
   //@brief Symbolic error information
   SymbolicError *symbolicError;
 
-  //@breif Used to generate return variable names for math function calls
-  int mathVarCount;
-
   std::string getFnAlias(std::string fn);
   void addFnAlias(std::string old_fn, std::string new_fn);
   void removeFnAlias(std::string fn);
@@ -176,8 +173,6 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
-
-  std::string getNewMathVarName(std::string mathFunctionName);
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -145,6 +145,9 @@ public:
   //@brief Symbolic error information
   SymbolicError *symbolicError;
 
+  //@breif Used to generate return variable names for math function calls
+  int mathVarCount;
+
   std::string getFnAlias(std::string fn);
   void addFnAlias(std::string old_fn, std::string new_fn);
   void removeFnAlias(std::string fn);
@@ -173,6 +176,10 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
+
+  std::string getNewMathVarName(std::string mathFunctionName);
+  ref<Expr> getNewSymbolicMathErrorVariable(ref<Expr> mathVar,
+                                            std::string mathVarName);
 };
 }
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -128,6 +128,10 @@ llvm::cl::opt<bool> Scaling(
         "Scale numerator of divisions to prevent rounding the result to zero"),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> MathCalls("math-calls",
+                              llvm::cl::desc("Handle math function calls"),
+                              llvm::cl::init(false));
+
 llvm::cl::opt<int>
 MultiKTest("multi-ktest", llvm::cl::init(0), llvm::cl::value_desc("number"),
            llvm::cl::desc("Try to produce a specified number of ktest files of "

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -862,6 +862,10 @@ ErrorState::getStateErrorExpressions() {
   return errorExpressions;
 }
 
+std::map<std::string, std::vector<Cell> > &ErrorState::getMathExpressions() {
+  return mathCallArgs;
+}
+
 ref<Expr> ErrorState::createNewMathErrorVar(ref<Expr> mathVar,
                                             std::string mathVarName) {
   const std::string errorVarName = "err_" + mathVarName;

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -870,3 +870,9 @@ ref<Expr> ErrorState::createNewMathErrorVar(ref<Expr> mathVar,
       UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
   return mathErrorVar;
 }
+
+void ErrorState::storeMathCallArgs(std::string varName,
+                                   std::vector<Cell> &arguments) {
+  // save the function call args
+  mathCallArgs[varName] = arguments;
+}

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -880,3 +880,10 @@ void ErrorState::storeMathCallArgs(std::string varName,
   // save the function call args
   mathCallArgs[varName] = arguments;
 }
+
+std::string ErrorState::createNewMathVarName(std::string mathFunctionName) {
+  mathVarCount++;
+  std::ostringstream str;
+  str << mathVarCount;
+  return mathFunctionName + "_" + str.str();
+}

--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -861,3 +861,12 @@ std::map<uint64_t, std::pair<std::string, ref<Expr> > > &
 ErrorState::getStateErrorExpressions() {
   return errorExpressions;
 }
+
+ref<Expr> ErrorState::createNewMathErrorVar(ref<Expr> mathVar,
+                                            std::string mathVarName) {
+  const std::string errorVarName = "err_" + mathVarName;
+  const Array *array = errorArrayCache->CreateArray(errorVarName, Expr::Int8);
+  ref<Expr> mathErrorVar = ReadExpr::create(
+      UpdateList(array, 0), ConstantExpr::create(0, array->getDomain()));
+  return mathErrorVar;
+}

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -109,6 +109,9 @@ public:
   std::map<uint64_t, std::pair<std::string, ref<Expr> > > &
   getStateErrorExpressions();
 
+  // Getter for math call functions and arguments
+  std::map<std::string, std::vector<Cell> > &getMathExpressions();
+
   /// dump - Print the object content to stderr
   void dump() const {
     print(llvm::errs());

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -54,9 +54,7 @@ private:
 
 public:
   ErrorState(ArrayCache *arrayCache)
-      : refCount(0), errorArrayCache(arrayCache) {
-    mathVarCount = 0;
-  }
+      : refCount(0), errorArrayCache(arrayCache), mathVarCount(0) {}
 
   ErrorState(ErrorState &errorState)
       : refCount(0), errorArrayCache(errorState.errorArrayCache) {

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -47,6 +47,8 @@ private:
 
   std::vector<ref<Expr> > inputErrorList;
 
+  std::map<std::string, std::vector<Cell> > mathCallArgs;
+
 public:
   ErrorState(ArrayCache *arrayCache)
       : refCount(0), errorArrayCache(arrayCache) {}
@@ -58,6 +60,7 @@ public:
     errorExpressions = errorState.errorExpressions;
     inputErrorList = errorState.inputErrorList;
     outputString = errorState.outputString;
+    mathCallArgs = errorState.mathCallArgs;
   }
 
   ~ErrorState();
@@ -113,6 +116,8 @@ public:
   }
 
   ref<Expr> createNewMathErrorVar(ref<Expr> mathVar, std::string mathVarName);
+
+  void storeMathCallArgs(std::string varName, std::vector<Cell> &arguments);
 };
 }
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -111,6 +111,8 @@ public:
     print(llvm::errs());
     llvm::errs() << "\n";
   }
+
+  ref<Expr> createNewMathErrorVar(ref<Expr> mathVar, std::string mathVarName);
 };
 }
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -49,9 +49,14 @@ private:
 
   std::map<std::string, std::vector<Cell> > mathCallArgs;
 
+  //@breif Used to generate return variable names for math function calls
+  int mathVarCount;
+
 public:
   ErrorState(ArrayCache *arrayCache)
-      : refCount(0), errorArrayCache(arrayCache) {}
+      : refCount(0), errorArrayCache(arrayCache) {
+    mathVarCount = 0;
+  }
 
   ErrorState(ErrorState &errorState)
       : refCount(0), errorArrayCache(errorState.errorArrayCache) {
@@ -61,6 +66,7 @@ public:
     inputErrorList = errorState.inputErrorList;
     outputString = errorState.outputString;
     mathCallArgs = errorState.mathCallArgs;
+    mathVarCount = errorState.mathVarCount;
   }
 
   ~ErrorState();
@@ -121,6 +127,8 @@ public:
   ref<Expr> createNewMathErrorVar(ref<Expr> mathVar, std::string mathVarName);
 
   void storeMathCallArgs(std::string varName, std::vector<Cell> &arguments);
+
+  std::string createNewMathVarName(std::string mathFunctionName);
 };
 }
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -392,11 +392,7 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 
 std::string ExecutionState::getNewMathVarName(std::string mathFunctionName) {
   mathVarCount++;
-  return mathFunctionName + "_";
-}
-
-ref<Expr>
-ExecutionState::getNewSymbolicMathErrorVariable(ref<Expr> mathVar,
-                                                std::string mathVarName) {
-  return symbolicError->getSymbolicMathErrorVar(mathVar, mathVarName);
+  std::ostringstream str;
+  str << mathVarCount;
+  return mathFunctionName + "_" + str.str();
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -77,10 +77,13 @@ ExecutionState::ExecutionState(KFunction *kf, ArrayCache *arrayCache)
     ref<Expr> scalingConstraint = symbolicError->getScalingConstraint();
     addConstraint(scalingConstraint);
   }
+  mathVarCount = 0;
 }
 
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
-    : constraints(assumptions), queryCost(0.), ptreeNode(0), symbolicError(0) {}
+    : constraints(assumptions), queryCost(0.), ptreeNode(0), symbolicError(0) {
+  mathVarCount = 0;
+}
 
 ExecutionState::~ExecutionState() {
   for (unsigned int i=0; i<symbolics.size(); i++)
@@ -126,6 +129,8 @@ ExecutionState::ExecutionState(const ExecutionState& state):
 {
   for (unsigned int i=0; i<symbolics.size(); i++)
     symbolics[i].first->refCount++;
+
+  mathVarCount = state.mathVarCount;
 }
 
 ExecutionState *ExecutionState::branch() {
@@ -383,4 +388,15 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
     out << "\n";
     target = sf.caller;
   }
+}
+
+std::string ExecutionState::getNewMathVarName(std::string mathFunctionName) {
+  mathVarCount++;
+  return mathFunctionName + "_";
+}
+
+ref<Expr>
+ExecutionState::getNewSymbolicMathErrorVariable(ref<Expr> mathVar,
+                                                std::string mathVarName) {
+  return symbolicError->getSymbolicMathErrorVar(mathVar, mathVarName);
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -77,12 +77,10 @@ ExecutionState::ExecutionState(KFunction *kf, ArrayCache *arrayCache)
     ref<Expr> scalingConstraint = symbolicError->getScalingConstraint();
     addConstraint(scalingConstraint);
   }
-  mathVarCount = 0;
 }
 
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
     : constraints(assumptions), queryCost(0.), ptreeNode(0), symbolicError(0) {
-  mathVarCount = 0;
 }
 
 ExecutionState::~ExecutionState() {
@@ -129,8 +127,6 @@ ExecutionState::ExecutionState(const ExecutionState& state):
 {
   for (unsigned int i=0; i<symbolics.size(); i++)
     symbolics[i].first->refCount++;
-
-  mathVarCount = state.mathVarCount;
 }
 
 ExecutionState *ExecutionState::branch() {
@@ -388,11 +384,4 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
     out << "\n";
     target = sf.caller;
   }
-}
-
-std::string ExecutionState::getNewMathVarName(std::string mathFunctionName) {
-  mathVarCount++;
-  std::ostringstream str;
-  str << mathVarCount;
-  return mathFunctionName + "_" + str.str();
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1329,23 +1329,6 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
   if (f && f->isDeclaration()) {
     switch(f->getIntrinsicID()) {
     case Intrinsic::not_intrinsic: {
-      // Here we replace cell vector with expression vector. We assume they are
-      // short.
-      /*std::vector<ref<Expr> > exprArguments;
-      for (std::vector<Cell>::iterator it = arguments.begin(),
-                                       ie = arguments.end();
-           it != ie; ++it) {
-        exprArguments.push_back(it->value);
-      }
-
-      //
-      std::vector<ref<Expr> > exprArgumentsError;
-                        for (std::vector<Cell>::iterator it = arguments.begin(),
-      ie =
-                                        arguments.end(); it != ie; ++it) {
-                                exprArgumentsError.push_back(it->error);
-                        }*/
-
       // state may be destroyed by this call, cannot touch
       callExternalFunction(state, ki, f, arguments);
       break;
@@ -3950,7 +3933,8 @@ void Executor::callExternalFunction(ExecutionState &state, KInstruction *target,
 
   if (MathCalls && externalMathCallsList.count(function->getName())) {
     // create new symbolic variable
-    std::string varName = state.getNewMathVarName(function->getName().str());
+    std::string varName =
+        state.symbolicError->getNewMathVarName(function->getName().str());
 
     const Array *array = arrayCache.CreateArray(varName, Expr::Int8);
     ref<Expr> newMathVar = ReadExpr::create(

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3929,7 +3929,7 @@ static std::set<std::string> okExternals(okExternalsList,
                                          okExternalsList + 
                                          (sizeof(okExternalsList)/sizeof(okExternalsList[0])));
 
-static const char *mathCallNames[] = { "sin", "sqrt", "abs", "fabs" };
+static const char *mathCallNames[] = { "sin", "cos", "sqrt", "abs", "fabs" };
 
 static std::set<std::string> externalMathCallsList(
     mathCallNames,

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -242,10 +242,8 @@ private:
 			    llvm::BasicBlock *src,
 			    ExecutionState &state);
 
-  void callExternalFunction(ExecutionState &state,
-                            KInstruction *target,
-                            llvm::Function *function,
-                            std::vector< ref<Expr> > &arguments);
+  void callExternalFunction(ExecutionState &state, KInstruction *target,
+                            llvm::Function *function, std::vector<Cell> &args);
 
   ObjectState *bindObjectInState(ExecutionState &state, const MemoryObject *mo,
                                  bool isLocal, const Array *array = 0);

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -206,6 +206,10 @@ public:
                                     std::string mathVarName) {
     return errorState->createNewMathErrorVar(mathVar, mathVarName);
   }
+
+  void saveMathCallArgs(std::string varName, std::vector<Cell> &arguments) {
+    errorState->storeMathCallArgs(varName, arguments);
+  }
 };
 }
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -183,6 +183,10 @@ public:
     return errorState->getStateErrorExpressions();
   }
 
+  std::map<std::string, std::vector<Cell> > &getMathCalls() {
+    return errorState->getMathExpressions();
+  }
+
   void addErrorConstraint(ref<Expr> error) {
     constraintsWithError.push_back(error);
   }

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -214,6 +214,10 @@ public:
   void saveMathCallArgs(std::string varName, std::vector<Cell> &arguments) {
     errorState->storeMathCallArgs(varName, arguments);
   }
+
+  std::string getNewMathVarName(std::string mathFunctionName) {
+    return errorState->createNewMathVarName(mathFunctionName);
+  }
 };
 }
 

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -201,6 +201,11 @@ public:
     addErrorConstraint(scalingConstraint);
     return scalingConstraint;
   }
+
+  ref<Expr> getSymbolicMathErrorVar(ref<Expr> mathVar,
+                                    std::string mathVarName) {
+    return errorState->createNewMathErrorVar(mathVar, mathVarName);
+  }
 };
 }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -568,6 +568,27 @@ void KleeHandler::processTestCase(const ExecutionState &state,
                                &(*itexp->second.second)) << "\n\n";
       }
       delete expressionFile;
+
+      if (MathCalls) {
+        llvm::raw_ostream *mathExpFile = openTestFile("mathf", id);
+        std::map<std::string, std::vector<Cell> > &mathCalls =
+            state.symbolicError->getMathCalls();
+        for (std::map<std::string, std::vector<Cell> >::const_iterator
+                 itmath = mathCalls.begin(),
+                 iemath = mathCalls.end();
+             itmath != iemath; ++itmath) {
+          *mathExpFile << itmath->first << "\n";
+          std::vector<Cell> args = itmath->second;
+          for (std::vector<Cell>::iterator itargs = args.begin();
+               itargs != args.end(); ++itargs) {
+            *mathExpFile << PrettyExpressionBuilder::construct(
+                                &(*itargs->value)) << ", "
+                         << PrettyExpressionBuilder::construct(
+                                &(*itargs->error)) << "\n\n";
+          }
+        }
+        delete mathExpFile;
+      }
     }
 
     if (errorMessage || WriteKQueries) {


### PR DESCRIPTION
For math function calls such as sin, sqrt, return a symbolic variable for the result and its error while noting down the function and its arguments. These math functions will then be evaluated with concrete input during the sensitivity analysis. 

Creates testxxx.mathf file for each state with the math function calls made. Testing code is attached. 
[test.txt](https://github.com/fp-analysis/klee/files/2189619/test.txt)
