### PR TITLE
Handle the case when target is null when calling executeStore()

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4309,8 +4309,8 @@ void Executor::executeMemoryOperation(
         } else {
           ObjectState *wos = state.addressSpace.getWriteable(mo, os);
           wos->write(offset, value);
-          state.symbolicError->executeStore(address, value, error,
-                                            valueWithError, target->inst);
+          state.symbolicError->executeStore(
+              address, value, error, valueWithError, target ? target->inst : 0);
         }
       } else {
         ref<Expr> result = os->read(offset, type);


### PR DESCRIPTION
In Executor::executeMemoryOperation(). This fixes the following segfault:
```
andrew@andrew-MacBook:~/projects/fp-analysis/fp-examples/loops$ make cnt.loop
clang -I/home/andrew/projects/fp-analysis/klee/build/include -I/home/andrew/projects/fp-analysis/klee/build/../include -c -emit-llvm -g -o cnt_123.bc cnt.c
opt -mem2reg < cnt_123.bc > cnt.bc
rm -f cnt_123.bc
EXTRA_OPTIONS="-loop-breaking" OUTPUT_DIR="cnt.loop" make cnt.klee
make[1]: Entering directory '/home/andrew/projects/fp-analysis/fp-examples/loops'
if [ -z "$OUTPUT_DIR" ] ; then \
	OUTPUT_DIR="cnt.klee" ; \
fi ; \
/home/andrew/projects/fp-analysis/klee/build/bin/klee -search=dfs -output-dir="$OUTPUT_DIR" $EXTRA_OPTIONS -precision cnt.bc
KLEE: output directory is "/home/andrew/projects/fp-analysis/fp-examples/loops/cnt.loop"
KLEE: Using STP solver backend
0  klee            0x0000000000f628e2 llvm::sys::PrintStackTrace(_IO_FILE*) + 50
1  klee            0x0000000000f62134
2  libpthread.so.0 0x000015064a07a390
3  klee            0x000000000057aefd klee::Executor::executeMemoryOperation(klee::ExecutionState&, bool, klee::Cell&, klee::ref<klee::Expr>, klee::ref<klee::Expr>, klee::ref<klee::Expr>, klee::KInstruction*) + 4813
4  klee            0x00000000005ae0cc klee::SymbolicError::breakLoop(klee::Executor*, klee::ExecutionState&, llvm::Instruction*, llvm::BasicBlock*&) + 1788
5  klee            0x0000000000585677 klee::Executor::run(klee::ExecutionState&) + 1927
6  klee            0x0000000000585da1 klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1649
7  klee            0x0000000000548900 main + 11280
8  libc.so.6       0x0000150648ff1830 __libc_start_main + 240
9  klee            0x000000000055bb29 _start + 41
Segmentation fault (core dumped)
Makefile:24: recipe for target 'cnt.klee' failed
make[1]: *** [cnt.klee] Error 139
make[1]: Leaving directory '/home/andrew/projects/fp-analysis/fp-examples/loops'
Makefile:33: recipe for target 'cnt.loop' failed
make: *** [cnt.loop] Error 2
rm cnt.bc
```
@Himeshi I will merge this since it is trivial, but please feel free to check later when you are free.