### PR TITLE
Expression print fix

### DIFF
--- a/lib/Core/ErrorState.cpp
+++ b/lib/Core/ErrorState.cpp
@@ -585,11 +585,17 @@ void ErrorState::executeStoreSimple(ref<Expr> address, ref<Expr> error,
 
       // update/save error expression
       if (tokens.size() > 5) {
+        std::string name;
         if (tokens.size() > 7) {
-          stream << ", " << tokens[4] << ", " << intAddress;
+          name = tokens[4];
         } else {
-          stream << ", " << tokens[2] << ", " << intAddress;
+          name = tokens[2];
         }
+        stream << ", " << name << ", " << intAddress;
+
+        if (name == "null")
+          return;
+
         std::map<uint64_t, std::pair<std::string, ref<Expr> > >::const_iterator
         it = errorExpressions.find(intAddress);
         if (it != errorExpressions.end()) {

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -85,7 +85,7 @@ public:
 
   void registerInputError(ref<Expr> error);
 
-  void executeStoreSimple(ref<Expr> address, ref<Expr> error,
+  void executeStoreSimple(ref<Expr> base, ref<Expr> address, ref<Expr> error,
                           ref<Expr> valueWithError, llvm::Instruction *inst);
 
   void declareInputError(ref<Expr> address, ref<Expr> error);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4333,8 +4333,9 @@ void Executor::executeMemoryOperation(
         } else {
           ObjectState *wos = state.addressSpace.getWriteable(mo, os);
           wos->write(offset, value);
-          state.symbolicError->executeStore(
-              address, value, error, valueWithError, target ? target->inst : 0);
+          state.symbolicError->executeStore(mo->getBaseExpr(), address, value,
+                                            error, valueWithError,
+                                            target ? target->inst : 0);
         }
       } else {
         ref<Expr> result = os->read(offset, type);
@@ -4382,8 +4383,9 @@ void Executor::executeMemoryOperation(
         } else {
           ObjectState *wos = bound->addressSpace.getWriteable(mo, os);
           wos->write(mo->getOffsetExpr(address), value);
-          state.symbolicError->executeStore(address, value, error,
-                                            valueWithError, target->inst);
+          state.symbolicError->executeStore(mo->getBaseExpr(), address, value,
+                                            error, valueWithError,
+                                            target->inst);
         }
       } else {
         ref<Expr> result = os->read(mo->getOffsetExpr(address), type);

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -250,8 +250,9 @@ SymbolicError::~SymbolicError() {
   nonExited.clear();
 }
 
-void SymbolicError::executeStore(ref<Expr> address, ref<Expr> value,
-                                 ref<Expr> error, ref<Expr> valueWithError,
+void SymbolicError::executeStore(ref<Expr> base, ref<Expr> address,
+                                 ref<Expr> value, ref<Expr> error,
+                                 ref<Expr> valueWithError,
                                  llvm::Instruction *inst) {
     if (LoopBreaking && !writesStack.empty()) {
       // Record the error at each store at each iteration.
@@ -269,7 +270,7 @@ void SymbolicError::executeStore(ref<Expr> address, ref<Expr> value,
         assert(!"non-constant address");
       }
     }
-    storeError(address, error, valueWithError, inst);
+    storeError(base, address, error, valueWithError, inst);
 }
 
 void SymbolicError::print(llvm::raw_ostream &os) const {

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -140,12 +140,13 @@ public:
 
   std::string &getOutputString() { return errorState->getOutputString(); }
 
-  void executeStore(ref<Expr> address, ref<Expr> value, ref<Expr> error,
-                    ref<Expr> valueWithError, llvm::Instruction *inst);
+  void executeStore(ref<Expr> base, ref<Expr> address, ref<Expr> value,
+                    ref<Expr> error, ref<Expr> valueWithError,
+                    llvm::Instruction *inst);
 
-  void storeError(ref<Expr> address, ref<Expr> error, ref<Expr> errorWithValue,
-                  llvm::Instruction *inst) {
-    errorState->executeStoreSimple(address, error, errorWithValue, inst);
+  void storeError(ref<Expr> base, ref<Expr> address, ref<Expr> error,
+                  ref<Expr> errorWithValue, llvm::Instruction *inst) {
+    errorState->executeStoreSimple(base, address, error, errorWithValue, inst);
   }
 
   void declareInputError(ref<Expr> address, ref<Expr> error) {


### PR DESCRIPTION
Fix issue of multiple expression for the same array variable. 

Based on our assumption that we consider that arrays will have uniform error and the array as a whole will be considered for approximation, having multiple expressions for different array elements is not desirable.  