### PR TITLE
Expression print fix

### DIFF
--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -85,8 +85,9 @@ public:
 
   void registerInputError(ref<Expr> error);
 
-  void executeStoreSimple(ref<Expr> base, ref<Expr> address, ref<Expr> error,
-                          ref<Expr> valueWithError, llvm::Instruction *inst);
+  void executeStoreSimple(ref<Expr> base, ref<Expr> address, ref<Expr> value,
+                          ref<Expr> error, ref<Expr> valueWithError,
+                          llvm::Instruction *inst);
 
   void declareInputError(ref<Expr> address, ref<Expr> error);
 

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -43,7 +43,7 @@ private:
 
   std::map<uintptr_t, std::pair<ref<Expr>, ref<Expr> > > storedError;
 
-  std::map<uint64_t, std::pair<std::string, ref<Expr> > > errorExpressions;
+  std::map<std::string, std::pair<std::string, ref<Expr> > > errorExpressions;
 
   std::vector<ref<Expr> > inputErrorList;
 
@@ -110,7 +110,7 @@ public:
   ref<Expr> getScalingConstraint();
 
   // Getter for error expressions
-  std::map<uint64_t, std::pair<std::string, ref<Expr> > > &
+  std::map<std::string, std::pair<std::string, ref<Expr> > > &
   getStateErrorExpressions();
 
   // Getter for math call functions and arguments

--- a/lib/Core/ErrorState.h
+++ b/lib/Core/ErrorState.h
@@ -96,6 +96,8 @@ public:
 
   bool hasStoredError(ref<Expr> address) const;
 
+  bool hasDeclaredInputError(ref<Expr> address) const;
+
   /// \brief Retrieve the error expression from the stored error expressions
   /// map. This returns 0 when the address is not found.
   std::pair<ref<Expr>, ref<Expr> > executeLoad(llvm::Instruction *inst,

--- a/lib/Core/PrettyExpressionBuilder.cpp
+++ b/lib/Core/PrettyExpressionBuilder.cpp
@@ -370,19 +370,33 @@ std::string PrettyExpressionBuilder::constructAShrByConstant(
 std::string PrettyExpressionBuilder::constructMulByConstant(std::string expr,
                                                             uint64_t x) {
   std::ostringstream stream;
-  stream << "(" << expr << " * " << x << ")";
+  if (x > 2147483648) {
+    uint32_t val = ~x + 1;
+    stream << "(" << expr << " * -" << val << ")";
+  } else
+    stream << "(" << expr << " * " << x << ")";
   return stream.str();
 }
 std::string PrettyExpressionBuilder::constructUDivByConstant(std::string expr,
                                                              uint64_t d) {
   std::ostringstream stream;
-  stream << "(" << expr << " / " << d << ")";
+  if (d > 2147483648) {
+    uint32_t val = ~d + 1;
+    stream << "(" << expr << " / -" << val << ")";
+  } else {
+    stream << "(" << expr << " / " << d << ")";
+  }
   return stream.str();
 }
 std::string PrettyExpressionBuilder::constructSDivByConstant(std::string expr,
                                                              uint64_t d) {
   std::ostringstream stream;
-  stream << "(" << expr << " / " << d << ")";
+  if (d > 2147483648) {
+    uint32_t val = ~d + 1;
+    stream << "(" << expr << " / -" << val << ")";
+  } else {
+    stream << "(" << expr << " / " << d << ")";
+  }
   return stream.str();
 }
 

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -270,6 +270,9 @@ void SymbolicError::executeStore(ref<Expr> base, ref<Expr> address,
         assert(!"non-constant address");
       }
     }
+    if (llvm::isa<ConstantExpr>(value)) {
+      base = value;
+    }
     storeError(base, address, error, valueWithError, inst);
 }
 

--- a/lib/Core/SymbolicError.cpp
+++ b/lib/Core/SymbolicError.cpp
@@ -270,10 +270,7 @@ void SymbolicError::executeStore(ref<Expr> base, ref<Expr> address,
         assert(!"non-constant address");
       }
     }
-    if (llvm::isa<ConstantExpr>(value)) {
-      base = value;
-    }
-    storeError(base, address, error, valueWithError, inst);
+    storeError(base, address, value, error, valueWithError, inst);
 }
 
 void SymbolicError::print(llvm::raw_ostream &os) const {

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -144,9 +144,11 @@ public:
                     ref<Expr> error, ref<Expr> valueWithError,
                     llvm::Instruction *inst);
 
-  void storeError(ref<Expr> base, ref<Expr> address, ref<Expr> error,
-                  ref<Expr> errorWithValue, llvm::Instruction *inst) {
-    errorState->executeStoreSimple(base, address, error, errorWithValue, inst);
+  void storeError(ref<Expr> base, ref<Expr> address, ref<Expr> value,
+                  ref<Expr> error, ref<Expr> errorWithValue,
+                  llvm::Instruction *inst) {
+    errorState->executeStoreSimple(base, address, value, error, errorWithValue,
+                                   inst);
   }
 
   void declareInputError(ref<Expr> address, ref<Expr> error) {

--- a/lib/Core/SymbolicError.h
+++ b/lib/Core/SymbolicError.h
@@ -179,7 +179,7 @@ public:
     return constraintsWithError;
   }
 
-  std::map<uint64_t, std::pair<std::string, ref<Expr> > > &
+  std::map<std::string, std::pair<std::string, ref<Expr> > > &
   getErrorExpressions() {
     return errorState->getStateErrorExpressions();
   }

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -556,9 +556,9 @@ void KleeHandler::processTestCase(const ExecutionState &state,
       }
 
       llvm::raw_ostream *expressionFile = openTestFile("expressions", id);
-      std::map<uint64_t, std::pair<std::string, ref<Expr> > > &expressions =
+      std::map<std::string, std::pair<std::string, ref<Expr> > > &expressions =
           state.symbolicError->getErrorExpressions();
-      for (std::map<uint64_t,
+      for (std::map<std::string,
                     std::pair<std::string, ref<Expr> > >::const_iterator
                itexp = expressions.begin(),
                ieexp = expressions.end();


### PR DESCRIPTION
- Change the unsigned two's complement integers into signed integers so that the sensitivity analysis can handle them directly
- Change the index of the errorExpressions map to a string containing the address and method name so that a variable with the same address which appears in multiple methods will be included in the sensitivity analysis result with the respective method name. 
- Enerj has @Approx annotations for function arguments. To obtain expressions this PR also processes the store instructions which handle the arguments. In case the argument is a pointer, we get the expression for error of the value it is pointing to, rather than the error of the pointer (which is zero)